### PR TITLE
Using HKPS instead of HKP

### DIFF
--- a/src/main/java/com/github/s4u/plugins/PGPKeysCache.java
+++ b/src/main/java/com/github/s4u/plugins/PGPKeysCache.java
@@ -55,6 +55,9 @@ public class PGPKeysCache {
         if ("hkp".equalsIgnoreCase(uri.getScheme())) {
             scheme = "http";
             port = 11371;
+        } else if ("hkps".equalsIgnoreCase(uri.getScheme())) {
+            scheme = "https";
+            port = 443;
         }
 
         uri = new URI(scheme, uri.getUserInfo(), uri.getHost(), port,

--- a/src/main/java/com/github/s4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/com/github/s4u/plugins/PGPVerifyMojo.java
@@ -111,11 +111,11 @@ public class PGPVerifyMojo extends AbstractMojo {
      *
      * @since 1.0.0
      */
-    @Parameter(property = "pgpverify.keyserver", defaultValue = "hkp://pool.sks-keyservers.net", required = true)
+    @Parameter(property = "pgpverify.keyserver", defaultValue = "hkps://pgp.mit.edu/", required = true)
     private String pgpKeyServer;
 
     /**
-     * Fail the build if some of dependency hasn't signature.
+     * Fail the build if any dependency lacks a signature.
      *
      * @since 1.1.0
      */


### PR DESCRIPTION
This PR makes the plugin pull keys over a TLS connection rather than an unencrypted one - but on the other hand, we only get them from the MIT server instead of the SKS pool of servers. So we're removing vulnerabilities to attacks on the path to the keyserver, but adding one on attacks on the keyserver itself. :(

The ideal case would be to use _both_ HKPS and the SKS pool, but unfortunately the SKS pool uses certificates that are not signed by a certificate authority resulting in PKIX Path Building exceptions everywhere.

It should be possible to pull down a copy of the SKS signing certificate (at https://sks-keyservers.net/sks-keyservers.netCA.pem), add it programmatically to the plugin's trust store, and then happily connect to SKS over HKPS - but doing all of that in Java is a tricky and somewhat ugly business. Regardless, I'm going to try and get a PR up to do just that to get the best of both worlds.

For more on programatically modifying the truststore, see: https://jcalcote.wordpress.com/2010/06/22/managing-a-dynamic-java-trust-store/