### PR TITLE
Stop kludging file extension into classifier

### DIFF
--- a/src/it/sigOkTestJar/pom.xml
+++ b/src/it/sigOkTestJar/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Slawomir Jaranowski
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test</artifactId>
+    <version>0.0.1-SNAPSHOTS</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.9.0</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.s4u.plugins</groupId>
+                <artifactId>pgpverify-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <failNoSignature>true</failNoSignature>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/sigOkTestJar/postbuild.bsh
+++ b/src/it/sigOkTestJar/postbuild.bsh
@@ -1,0 +1,5 @@
+import java.io.*;
+
+File asc = new File(basedir, "../../it-repo/org/apache/logging/log4j/log4j-core/2.9.0/log4j-core-2.9.0-tests.jar.asc");
+
+return asc.exists() && asc.isFile() && asc.length() > 0;

--- a/src/main/java/com/github/s4u/plugins/AscArtifactHandler.java
+++ b/src/main/java/com/github/s4u/plugins/AscArtifactHandler.java
@@ -58,7 +58,7 @@ public class AscArtifactHandler implements ArtifactHandler {
 
     @Override
     public boolean isIncludesDependencies() {
-        return false;
+        return wrappedHandler.isIncludesDependencies();
     }
 
     @Override

--- a/src/main/java/com/github/s4u/plugins/AscArtifactHandler.java
+++ b/src/main/java/com/github/s4u/plugins/AscArtifactHandler.java
@@ -1,0 +1,73 @@
+package com.github.s4u.plugins;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+
+/**
+ * Wrapper around an {@code ArtifactHandler} for an artifact, to retrieve its
+ * PGP signature file.
+ */
+public class AscArtifactHandler implements ArtifactHandler {
+    private ArtifactHandler wrappedHandler;
+
+    /**
+     * Initializes a new ASC Artifact Handler for the provided artifact.
+     *
+     * @param targetArtifact
+     *   The artifact for which a GPG signature artifact is desired.
+     */
+    public AscArtifactHandler(Artifact targetArtifact) {
+      this(targetArtifact.getArtifactHandler());
+    }
+
+    /**
+     * Initializes a new ASC Artifact Handler to wrap the provided regular
+     * artifact handler.
+     *
+     * The GPG signature file returned will correspond to the artifact that the
+     * specified artifact handler resolves.
+     *
+     * @param wrappedHandler
+     *   An artifact handler that will be wrapped by this ASC Artifact Handler,
+     *   such that all information about the target artifact come from the
+     *   provided handler, except for the file extension (".asc").
+     */
+    public AscArtifactHandler(ArtifactHandler wrappedHandler) {
+      this.wrappedHandler = wrappedHandler;
+    }
+
+    @Override
+    public String getExtension() {
+        return wrappedHandler.getExtension() + ".asc";
+    }
+
+    @Override
+    public String getDirectory() {
+        return wrappedHandler.getDirectory();
+    }
+
+    @Override
+    public String getClassifier() {
+        return wrappedHandler.getClassifier();
+    }
+
+    @Override
+    public String getPackaging() {
+        return wrappedHandler.getPackaging();
+    }
+
+    @Override
+    public boolean isIncludesDependencies() {
+        return false;
+    }
+
+    @Override
+    public String getLanguage() {
+        return wrappedHandler.getLanguage();
+    }
+
+    @Override
+    public boolean isAddedToClasspath() {
+        return wrappedHandler.isAddedToClasspath();
+    }
+}

--- a/src/main/java/com/github/s4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/com/github/s4u/plugins/PGPVerifyMojo.java
@@ -288,9 +288,8 @@ public class PGPVerifyMojo extends AbstractMojo {
      */
     private ArtifactResolutionRequest getArtifactResolutionRequestForPom(Artifact artifact) {
 
-        Artifact aAsc = repositorySystem.createArtifactWithClassifier(
-                artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(),
-                "pom", artifact.getClassifier());
+        Artifact aAsc = repositorySystem.createProjectArtifact(
+                artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
 
         ArtifactResolutionRequest rreq = new ArtifactResolutionRequest();
         rreq.setArtifact(aAsc);

--- a/src/main/java/com/github/s4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/com/github/s4u/plugins/PGPVerifyMojo.java
@@ -267,9 +267,12 @@ public class PGPVerifyMojo extends AbstractMojo {
 
         Artifact aAsc = repositorySystem.createArtifactWithClassifier(
                 artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(),
-                artifact.getType() + ".asc", artifact.getClassifier());
+                artifact.getType(), artifact.getClassifier());
 
         ArtifactResolutionRequest rreq = new ArtifactResolutionRequest();
+
+        aAsc.setArtifactHandler(new AscArtifactHandler(aAsc));
+
         rreq.setArtifact(aAsc);
         rreq.setResolveTransitively(false);
         rreq.setLocalRepository(localRepository);


### PR DESCRIPTION
Previous approach blindly appended ".asc" to the classifier, breaking resolution for special artifacts like test JARs. Maven resolves these artifacts to a packaging type and file extension of "jar", but wasn't doing this here because the classifiers didn't match (since it had ".asc" at the end).

New approach provides the original classifier to Maven for it to apply standard look-up rules, then uses a new AscArtifactHandler that decorates the ArtifactHandler Maven returns for the artifact so that we fetch an artifact ending in ".asc".

Closes #22.