### PR TITLE
WIP: Re-factor PGP client to add retry support

### DIFF
--- a/src/main/java/org/simplify4u/plugins/PGPKeysCache.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysCache.java
@@ -104,7 +104,7 @@ public class PGPKeysCache {
                 outputStream,
                 new TransientFailureRetryStrategy() {
                     @Override
-                    public void onRetry(URL url, IOException cause) {
+                    public void onRetry(final URL url, final IOException cause) {
                         super.onRetry(url, cause);
 
                         log.warn(
@@ -115,6 +115,18 @@ public class PGPKeysCache {
                                 this.getMaxRetryCount(),
                                 url,
                                 cause.toString()));
+                    }
+
+                    @Override
+                    public void onBackoff(final URL url, final long delay) {
+                        super.onBackoff(url, delay);
+
+                        log.warn(
+                            String.format(
+                                "[Retry %d of %d] Backing off for %d milliseconds...",
+                                this.getCurrentRetryCount(),
+                                this.getMaxRetryCount(),
+                                delay));
                     }
                 });
         } catch (IOException e) {

--- a/src/main/java/org/simplify4u/plugins/PGPKeysCache.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysCache.java
@@ -23,18 +23,18 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-
-import com.google.common.io.ByteStreams;
 import org.apache.maven.plugin.logging.Log;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
 import org.bouncycastle.openpgp.PGPUtil;
 import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
+import org.simplify4u.plugins.failurestrategies.TransientFailureRetryStrategy;
 
 /**
  * @author Slawomir Jaranowski.
@@ -83,8 +83,8 @@ public class PGPKeysCache {
     }
 
     private void receiveKey(File keyFile, long keyID) throws IOException {
-
         File dir = keyFile.getParentFile();
+
         if (dir == null) {
             throw new IOException("No parent dir for: " + keyFile);
         }
@@ -97,9 +97,26 @@ public class PGPKeysCache {
             throw new IOException("Can't create directory: " + dir);
         }
 
-        try (InputStream inputStream = keysServerClient.getInputStreamForKey(keyID);
-             BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(keyFile))) {
-            ByteStreams.copy(inputStream, outputStream);
+        try (BufferedOutputStream outputStream = new BufferedOutputStream(
+                 new FileOutputStream(keyFile))) {
+            keysServerClient.copyKeyToOutputStream(
+                keyID,
+                outputStream,
+                new TransientFailureRetryStrategy() {
+                    @Override
+                    public void onRetry(URL url, IOException cause) {
+                        super.onRetry(url, cause);
+
+                        log.warn(
+                            String.format(
+                                "[Retry %d of %d] Attempting key request from %s "
+                                + "after error: \"%s\"",
+                                this.getCurrentRetryCount(),
+                                this.getMaxRetryCount(),
+                                url,
+                                cause.toString()));
+                    }
+                });
         } catch (IOException e) {
             // if error try remove file
             deleteFile(keyFile);

--- a/src/main/java/org/simplify4u/plugins/PGPKeysServerClient.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysServerClient.java
@@ -184,10 +184,14 @@ abstract class PGPKeysServerClient {
      */
     void copyKeyToOutputStream(long keyId, OutputStream outputStream,
                                final RequestFailureStrategy failureStrategy) throws IOException {
-        final URL keyUrl = getUriForGetKey(keyId).toURL();
+        // Allow us to cycle through servers in DNS-based round-robin pools
+        java.security.Security.setProperty("networkaddress.cache.ttl", "1");
+
         boolean shouldRetry = false;
 
         do {
+            // Re-generate URL to allow cycling servers in DNS-based round-robin pools
+            final URL keyUrl = getUriForGetKey(keyId).toURL();
             final URLConnection connection = this.getConnectionForKeyUrl(keyUrl);
 
             try (final InputStream inputStream = connection.getInputStream()) {

--- a/src/main/java/org/simplify4u/plugins/PGPKeysServerClient.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysServerClient.java
@@ -35,7 +35,7 @@ import org.simplify4u.plugins.failurestrategies.RequestFailureStrategy;
  */
 abstract class PGPKeysServerClient {
     private static final int DEFAULT_CONNECT_TIMEOUT = 5000;
-    private static final int DEFAULT_READ_TIMEOUT = 10000;
+    private static final int DEFAULT_READ_TIMEOUT = 20000;
 
     private final URI keyserver;
     private final int connectTimeout;

--- a/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttp.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttp.java
@@ -16,34 +16,42 @@
 package org.simplify4u.plugins;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
 
 /**
  * Implementation of PGPKeysServerClient for HTTP protocol.
  */
 class PGPKeysServerClientHttp extends PGPKeysServerClient {
-
-    protected PGPKeysServerClientHttp(URI keyserver) throws URISyntaxException {
-        super(keyserver);
+    protected PGPKeysServerClientHttp(final URI keyserver, final int connectTimeout,
+                                      final int readTimeout)
+    throws URISyntaxException {
+        super(keyserver, connectTimeout, readTimeout);
     }
 
     @Override
-    protected URI prepareKeyServerURI(URI keyserver) throws URISyntaxException {
+    protected URI prepareKeyServerURI(URI keyServer) throws URISyntaxException {
 
         int port = -1;
-        if (keyserver.getPort() > 0) {
-            port = keyserver.getPort();
-        } else if ("hkp".equalsIgnoreCase(keyserver.getScheme())) {
+
+        if (keyServer.getPort() > 0) {
+            port = keyServer.getPort();
+        } else if ("hkp".equalsIgnoreCase(keyServer.getScheme())) {
             port = 11371;
         }
-        return new URI("http", keyserver.getUserInfo(), keyserver.getHost(), port, null, null, null);
+
+        return new URI(
+            "http", keyServer.getUserInfo(), keyServer.getHost(), port, null, null, null);
     }
 
     @Override
-    protected InputStream getInputStreamForKey(URL keyURL) throws IOException {
-        return keyURL.openStream();
+    protected URLConnection getConnectionForKeyUrl(URL keyUrl) throws IOException {
+        final URLConnection connection = keyUrl.openConnection();
+
+        this.applyTimeouts(connection);
+
+        return connection;
     }
 }

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Wren Security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.simplify4u.plugins.failurestrategies;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * A failure strategy that will retry up to N times, backing off a longer period of time between
+ * attempts to allow the target server to recover.
+ *
+ * <p>By default, this strategy will allow retrying up to four times, with an additional 500
+ * milliseconds more per attempt, before giving up. The maximum number of retries can be controlled
+ * by using the {@link #BackoffStrategy(int)} constructor.
+ *
+ * <p>As expected, instances of this strategy maintain a retry counter. For this
+ * reason, after a request has been completed, the same failure strategy
+ * instance should not be used for a subsequent request. A new failure strategy
+ * instance should be created for each new request (excluding retries of the
+ * same request).
+ */
+public class BackoffStrategy extends RetryNTimesStrategy {
+    public static final int DEFAULT_BACKOFF_SCALAR = 500;
+
+    private final int backoffScalar;
+
+    /**
+     * Constructor for {@code BackoffStrategy}.
+     *
+     * <p>Creates a retry strategy that will allow retrying the same request up
+     * to four times.
+     */
+    public BackoffStrategy() {
+        this(DEFAULT_MAX_RETRY_COUNT, DEFAULT_BACKOFF_SCALAR);
+    }
+
+    /**
+     * Constructor for {@code BackoffStrategy}.
+     *
+     * <p>Creates a retry strategy that will allow retrying the same request up to four times, with
+     * the specified number of milliseconds of delay added to each additional attempt. For example,
+     * {@code 500} would cause the first retry to happen half a second later, the second retry one
+     * second later, the third one and a half seconds later, and so on.
+     *
+     * @param backoffScalar
+     *   The number of milliseconds to add to each retry attempt. The delay is cumulative, so each
+     *   retry takes longer than the previous one.
+     */
+    public BackoffStrategy(int backoffScalar) {
+        this(backoffScalar, DEFAULT_MAX_RETRY_COUNT);
+    }
+
+    /**
+     * Constructor for {@code BackoffStrategy}.
+     *
+     * <p>Creates a retry strategy that will allow retrying the same request up
+     * to the specified number of times, with the specified number of milliseconds of delay added to
+     * each additional attempt. For example, {@code 500} would cause the first retry to happen
+     * half a second later, the second retry one second later, the third one and a half seconds
+     * later, and so on.
+     *
+     * @param backoffScalar
+     *   The number of milliseconds to add to each retry attempt. The delay is cumulative, so each
+     *   retry takes longer than the previous one.
+     * @param maxRetryCount
+     *   The maximum number of times that the request can be retried.
+     */
+    public BackoffStrategy(int backoffScalar, int maxRetryCount) {
+        super(maxRetryCount);
+
+        this.backoffScalar = backoffScalar;
+    }
+
+    @Override
+    public void onRetry(URL url, IOException cause) {
+        super.onRetry(url, cause);
+
+        try {
+            Thread.sleep(this.getCurrentRetryCount() * backoffScalar);
+        } catch (InterruptedException ex) {
+            throw new IllegalStateException("Interrupted during retry", ex);
+        }
+    }
+}

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
@@ -23,9 +23,9 @@ import java.net.URL;
  * A failure strategy that will retry up to N times, backing off a longer period of time between
  * attempts to allow the target server to recover.
  *
- * <p>By default, this strategy will allow retrying up to four times, with an additional 500
- * milliseconds more per attempt, before giving up. The maximum number of retries can be controlled
- * by using the {@link #BackoffStrategy(int)} constructor.
+ * <p>By default, this strategy will allow retrying up to ten times, with an additional 500
+ * milliseconds more per attempt, before giving up. The delay between retries and maximum number of
+ * retries can be controlled by using the {@link #BackoffStrategy(long, int)} constructor.
  *
  * <p>As expected, instances of this strategy maintain a retry counter. For this
  * reason, after a request has been completed, the same failure strategy

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
@@ -85,12 +85,30 @@ public class BackoffStrategy extends RetryNTimesStrategy {
         this.backoffScalar = backoffScalar;
     }
 
+    /**
+     * Callback to notify the strategy that a request to the specified URL is being delayed for
+     * the specified amount of time.
+     *
+     * <p>This "back-off" is being attempted in an effort to allow a remote server to recover.
+     *
+     * @param url
+     *   The URL that is being retried.
+     * @param delay
+     *   The amount of time (in milliseconds) until the retry will be attempted.
+     */
+    public void onBackoff(final URL url, final long delay) {
+        // No-op -- subclasses can override for logging
+    }
+
     @Override
-    public void onRetry(URL url, IOException cause) {
+    public void onRetry(final URL url, final IOException cause) {
         super.onRetry(url, cause);
 
         try {
-            Thread.sleep(this.getCurrentRetryCount() * backoffScalar);
+            final long delay = this.getCurrentRetryCount() * this.backoffScalar;
+
+            this.onBackoff(url, delay);
+            Thread.sleep(delay);
         } catch (InterruptedException ex) {
             throw new IllegalStateException("Interrupted during retry", ex);
         }

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
@@ -23,7 +23,7 @@ import java.net.URL;
  * A failure strategy that will retry up to N times, backing off a longer period of time between
  * attempts to allow the target server to recover.
  *
- * <p>By default, this strategy will allow retrying up to ten times, with an additional 500
+ * <p>By default, this strategy will allow retrying up to ten times, with an additional 2000
  * milliseconds more per attempt, before giving up. The delay between retries and maximum number of
  * retries can be controlled by using the {@link #BackoffStrategy(long, int)} constructor.
  *
@@ -34,7 +34,10 @@ import java.net.URL;
  * same request).
  */
 public class BackoffStrategy extends RetryNTimesStrategy {
-    public static final long DEFAULT_BACKOFF_SCALAR = 500;
+    /**
+     * Default back-off: +2000 ms per retry.
+     */
+    public static final long DEFAULT_BACKOFF_SCALAR = 2000;
 
     private final long backoffScalar;
 

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/BackoffStrategy.java
@@ -34,24 +34,24 @@ import java.net.URL;
  * same request).
  */
 public class BackoffStrategy extends RetryNTimesStrategy {
-    public static final int DEFAULT_BACKOFF_SCALAR = 500;
+    public static final long DEFAULT_BACKOFF_SCALAR = 500;
 
-    private final int backoffScalar;
+    private final long backoffScalar;
 
     /**
      * Constructor for {@code BackoffStrategy}.
      *
      * <p>Creates a retry strategy that will allow retrying the same request up
-     * to four times.
+     * to ten times.
      */
     public BackoffStrategy() {
-        this(DEFAULT_MAX_RETRY_COUNT, DEFAULT_BACKOFF_SCALAR);
+        this(DEFAULT_BACKOFF_SCALAR, DEFAULT_MAX_RETRY_COUNT);
     }
 
     /**
      * Constructor for {@code BackoffStrategy}.
      *
-     * <p>Creates a retry strategy that will allow retrying the same request up to four times, with
+     * <p>Creates a retry strategy that will allow retrying the same request up to ten times, with
      * the specified number of milliseconds of delay added to each additional attempt. For example,
      * {@code 500} would cause the first retry to happen half a second later, the second retry one
      * second later, the third one and a half seconds later, and so on.
@@ -60,7 +60,7 @@ public class BackoffStrategy extends RetryNTimesStrategy {
      *   The number of milliseconds to add to each retry attempt. The delay is cumulative, so each
      *   retry takes longer than the previous one.
      */
-    public BackoffStrategy(int backoffScalar) {
+    public BackoffStrategy(long backoffScalar) {
         this(backoffScalar, DEFAULT_MAX_RETRY_COUNT);
     }
 
@@ -79,7 +79,7 @@ public class BackoffStrategy extends RetryNTimesStrategy {
      * @param maxRetryCount
      *   The maximum number of times that the request can be retried.
      */
-    public BackoffStrategy(int backoffScalar, int maxRetryCount) {
+    public BackoffStrategy(long backoffScalar, int maxRetryCount) {
         super(maxRetryCount);
 
         this.backoffScalar = backoffScalar;

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/NoRetryStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/NoRetryStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Wren Security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.simplify4u.plugins.failurestrategies;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * A failure strategy that does not allow retrying any failed requests.
+ */
+public class NoRetryStrategy implements RequestFailureStrategy {
+    @Override
+    public boolean canRetry(final URL url, final URLConnection connection,
+                            final IOException cause) {
+        return false;
+    }
+
+    @Override
+    public void onRetry(final URL url, final IOException cause) {
+        // No-op -- will never be invoked.
+    }
+}

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/RequestFailureStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/RequestFailureStrategy.java
@@ -48,7 +48,7 @@ public interface RequestFailureStrategy {
                      final IOException cause);
 
     /**
-     * Notifies the strategy that a request to the specified URL is being
+     * Callback to notify the strategy that a request to the specified URL is being
      * attempted after the specified exception caused the last attempt to fail.
      *
      * @param url

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/RequestFailureStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/RequestFailureStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Wren Security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.simplify4u.plugins.failurestrategies;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * An interface for controlling how failures during HTTP requests are handled.
+ *
+ * <p>Most instances of this interface maintain a retry counter. For this
+ * reason, after a request has been completed, the same failure strategy
+ * instance should not be used for a subsequent requests. A new failure strategy
+ * instance should be created for each new request (excluding retries of the
+ * same request).
+ */
+public interface RequestFailureStrategy {
+    /**
+     * Indicate whether or not this strategy is willing to allow the request to
+     * be retried.
+     *
+     * @param url
+     *   The URL that was being requested.
+     * @param connection
+     *   The connection that failed.
+     * @param cause
+     *   The exception that was returned when the connection failed.
+     *
+     * @return  Whether or not a request to the specified URL can be retried if
+     *          the cause of the failure was the specified exception.
+     */
+    boolean canRetry(final URL url, final URLConnection connection,
+                     final IOException cause);
+
+    /**
+     * Notifies the strategy that a request to the specified URL is being
+     * attempted after the specified exception caused the last attempt to fail.
+     *
+     * @param url
+     *   The URL that is being retried.
+     * @param cause
+     *   The exception that was returned when the previous connection failed.
+     */
+    void onRetry(final URL url, final IOException cause);
+}

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/RetryNTimesStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/RetryNTimesStrategy.java
@@ -55,6 +55,9 @@ public class RetryNTimesStrategy implements RequestFailureStrategy {
      *
      * <p>Creates a retry strategy that will allow retrying the same request up
      * to the specified number of times.
+     *
+     * @param maxRetryCount
+     *   The maximum number of times that the request can be retried.
      */
     public RetryNTimesStrategy(final int maxRetryCount) {
         this.maxRetryCount      = maxRetryCount;

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/RetryNTimesStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/RetryNTimesStrategy.java
@@ -23,7 +23,7 @@ import java.net.URLConnection;
 /**
  * A failure strategy that automatically retries a request up to N times..
  *
- * <p>By default, this strategy will allow retrying up to four times before
+ * <p>By default, this strategy will allow retrying up to ten times before
  * giving up. The maximum number of retries can be controlled by using the
  * {@link #RetryNTimesStrategy(int)} constructor.
  *
@@ -34,7 +34,7 @@ import java.net.URLConnection;
  * same request).
  */
 public class RetryNTimesStrategy implements RequestFailureStrategy {
-    public static final int DEFAULT_MAX_RETRY_COUNT = 4;
+    public static final int DEFAULT_MAX_RETRY_COUNT = 10;
 
     private final int maxRetryCount;
 
@@ -44,7 +44,7 @@ public class RetryNTimesStrategy implements RequestFailureStrategy {
      * Constructor for {@code RetryNTimesStrategy}.
      *
      * <p>Creates a retry strategy that will allow retrying the same request up
-     * to four times.
+     * to ten times.
      */
     public RetryNTimesStrategy() {
         this(DEFAULT_MAX_RETRY_COUNT);

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/RetryNTimesStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/RetryNTimesStrategy.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Wren Security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.simplify4u.plugins.failurestrategies;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * A failure strategy that automatically retries a request up to N times..
+ *
+ * <p>By default, this strategy will allow retrying up to four times before
+ * giving up. The maximum number of retries can be controlled by using the
+ * {@link #RetryNTimesStrategy(int)} constructor.
+ *
+ * <p>As expected, instances of this strategy maintain a retry counter. For this
+ * reason, after a request has been completed, the same failure strategy
+ * instance should not be used for a subsequent request. A new failure strategy
+ * instance should be created for each new request (excluding retries of the
+ * same request).
+ */
+public class RetryNTimesStrategy implements RequestFailureStrategy {
+    public static final int DEFAULT_MAX_RETRY_COUNT = 4;
+
+    private final int maxRetryCount;
+
+    private int currentRetryCount;
+
+    /**
+     * Constructor for {@code RetryNTimesStrategy}.
+     *
+     * <p>Creates a retry strategy that will allow retrying the same request up
+     * to four times.
+     */
+    public RetryNTimesStrategy() {
+        this(DEFAULT_MAX_RETRY_COUNT);
+    }
+
+    /**
+     * Constructor for {@code RetryNTimesStrategy}.
+     *
+     * <p>Creates a retry strategy that will allow retrying the same request up
+     * to the specified number of times.
+     */
+    public RetryNTimesStrategy(final int maxRetryCount) {
+        this.maxRetryCount      = maxRetryCount;
+        this.currentRetryCount  = 0;
+    }
+
+    /**
+     * Gets the maximum number of retries that this instance will attempt.
+     *
+     * @return  The maximum number of retries to attempt.
+     */
+    public int getMaxRetryCount() {
+        return maxRetryCount;
+    }
+
+    /**
+     * Gets the number of retries attempted so far for this instance.
+     *
+     * @return  The number of retries that have been attempted.
+     */
+    public int getCurrentRetryCount() {
+        return this.currentRetryCount;
+    }
+
+    @Override
+    public boolean canRetry(final URL url, final URLConnection connection,
+                            final IOException cause) {
+        return this.currentRetryCount < this.maxRetryCount;
+    }
+
+    @Override
+    public void onRetry(URL url, IOException cause) {
+        ++this.currentRetryCount;
+    }
+}

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
@@ -114,9 +114,13 @@ public class TransientFailureRetryStrategy extends BackoffStrategy {
     }
 
     private boolean canRetryExceptionType(final IOException cause) {
-        return RETRYABLE_EXCEPTION_TYPES
-            .stream()
-            .anyMatch((exceptionType) -> exceptionType.isInstance(cause));
+        for (Class<? extends IOException> exceptionType : RETRYABLE_EXCEPTION_TYPES) {
+            if (exceptionType.isInstance(cause)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private boolean canRetryStatusCode(URLConnection connection) {

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
@@ -123,6 +123,7 @@ public class TransientFailureRetryStrategy extends BackoffStrategy {
         return false;
     }
 
+    @SuppressWarnings("PMD.EmptyCatchBlock")
     private boolean canRetryStatusCode(URLConnection connection) {
         boolean canRetry = false;
 

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
@@ -78,6 +78,9 @@ public class TransientFailureRetryStrategy extends RetryNTimesStrategy {
      *
      * <p>Creates a retry strategy that will allow retrying the same request up
      * to the specified number of times.
+     *
+     * @param maxRetryCount
+     *   The maximum number of times that the request can be retried.
      */
     public TransientFailureRetryStrategy(final int maxRetryCount) {
         super(maxRetryCount);

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 /**
  * A failure strategy that automatically retries transient HTTP failures
- * (timeouts and some 5XX errors).
+ * (timeouts, 408 errors, and some 5XX errors).
  *
  * <p>By default, this strategy will allow retrying up to four times before
  * giving up. The maximum number of retries can be controlled by using the
@@ -57,6 +57,7 @@ public class TransientFailureRetryStrategy extends BackoffStrategy {
     private static final List<Integer> RETRYABLE_STATUS_CODES =
         Collections.unmodifiableList(
             Arrays.asList(
+                HttpURLConnection.HTTP_CLIENT_TIMEOUT,
                 HttpURLConnection.HTTP_INTERNAL_ERROR,
                 HttpURLConnection.HTTP_BAD_GATEWAY,
                 HttpURLConnection.HTTP_UNAVAILABLE,

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
@@ -30,7 +30,7 @@ import java.util.List;
  * A failure strategy that automatically retries transient HTTP failures
  * (timeouts, 408 errors, and some 5XX errors).
  *
- * <p>By default, this strategy will allow retrying up to four times before
+ * <p>By default, this strategy will allow retrying up to ten times before
  * giving up. The maximum number of retries can be controlled by using the
  * {@link #TransientFailureRetryStrategy(int)} constructor.
  *
@@ -68,7 +68,7 @@ public class TransientFailureRetryStrategy extends BackoffStrategy {
      * Constructor for {@code TransientFailureRetryStrategy}.
      *
      * <p>Creates a retry strategy that will allow retrying the same request up
-     * to four times.
+     * to ten times.
      */
     public TransientFailureRetryStrategy() {
         super(DEFAULT_BACKOFF_SCALAR, DEFAULT_MAX_RETRY_COUNT);

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 Wren Security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.simplify4u.plugins.failurestrategies;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A failure strategy that automatically retries transient HTTP failures
+ * (timeouts and some 5XX errors).
+ *
+ * <p>By default, this strategy will allow retrying up to four times before
+ * giving up. The maximum number of retries can be controlled by using the
+ * {@link #TransientFailureRetryStrategy(int)} constructor.
+ *
+ * <p>Instances of this strategy maintain a retry counter. For this reason,
+ * after a request has been completed, the same failure strategy instance should
+ * not be used for any subsequent requests. A new failure strategy instance
+ * should be created for each new request (excluding retries of the same
+ * request).
+ */
+public class TransientFailureRetryStrategy extends RetryNTimesStrategy {
+    /**
+     * The list of exception types that signal request failures that may recover after a retry.
+     */
+    private static final List<Class<? extends IOException>> RETRYABLE_EXCEPTION_TYPES =
+        Collections.unmodifiableList(
+            Arrays.asList(
+                ConnectException.class,
+                SocketTimeoutException.class
+            ));
+
+    /**
+     * The list of HTTP status codes that signal request failures that may recover after a retry.
+     */
+    private static final List<Integer> RETRYABLE_STATUS_CODES =
+        Collections.unmodifiableList(
+            Arrays.asList(
+                HttpURLConnection.HTTP_INTERNAL_ERROR,
+                HttpURLConnection.HTTP_BAD_GATEWAY,
+                HttpURLConnection.HTTP_UNAVAILABLE,
+                HttpURLConnection.HTTP_GATEWAY_TIMEOUT
+            ));
+
+    /**
+     * Constructor for {@code TransientFailureRetryStrategy}.
+     *
+     * <p>Creates a retry strategy that will allow retrying the same request up
+     * to four times.
+     */
+    public TransientFailureRetryStrategy() {
+        this(DEFAULT_MAX_RETRY_COUNT);
+    }
+
+    /**
+     * Constructor for {@code TransientFailureRetryStrategy}.
+     *
+     * <p>Creates a retry strategy that will allow retrying the same request up
+     * to the specified number of times.
+     */
+    public TransientFailureRetryStrategy(final int maxRetryCount) {
+        super(maxRetryCount);
+    }
+
+    @Override
+    public boolean canRetry(final URL url, final URLConnection connection,
+                            final IOException cause) {
+        return super.canRetry(url, connection, cause)
+            && (canRetryExceptionType(cause) || canRetryStatusCode(connection));
+    }
+
+    private boolean canRetryExceptionType(final IOException cause) {
+        return RETRYABLE_EXCEPTION_TYPES
+            .stream()
+            .anyMatch((exceptionType) -> exceptionType.isInstance(cause));
+    }
+
+    private boolean canRetryStatusCode(URLConnection connection) {
+        boolean canRetry = false;
+
+        if (connection instanceof HttpURLConnection) {
+            try {
+                final int responseCode = ((HttpURLConnection) connection).getResponseCode();
+
+                canRetry = RETRYABLE_STATUS_CODES.contains(responseCode);
+            } catch (IOException ex) {
+                // Should not happen -- by now we should have the status code.
+                // In this case, we assume we cannot retry.
+            }
+        }
+
+        return canRetry;
+    }
+}

--- a/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
+++ b/src/main/java/org/simplify4u/plugins/failurestrategies/TransientFailureRetryStrategy.java
@@ -40,7 +40,7 @@ import java.util.List;
  * should be created for each new request (excluding retries of the same
  * request).
  */
-public class TransientFailureRetryStrategy extends RetryNTimesStrategy {
+public class TransientFailureRetryStrategy extends BackoffStrategy {
     /**
      * The list of exception types that signal request failures that may recover after a retry.
      */
@@ -70,7 +70,7 @@ public class TransientFailureRetryStrategy extends RetryNTimesStrategy {
      * to four times.
      */
     public TransientFailureRetryStrategy() {
-        this(DEFAULT_MAX_RETRY_COUNT);
+        super(DEFAULT_BACKOFF_SCALAR, DEFAULT_MAX_RETRY_COUNT);
     }
 
     /**
@@ -83,7 +83,26 @@ public class TransientFailureRetryStrategy extends RetryNTimesStrategy {
      *   The maximum number of times that the request can be retried.
      */
     public TransientFailureRetryStrategy(final int maxRetryCount) {
-        super(maxRetryCount);
+        super(DEFAULT_BACKOFF_SCALAR, maxRetryCount);
+    }
+
+    /**
+     * Constructor for {@code TransientFailureRetryStrategy}.
+     *
+     * <p>Creates a retry strategy that will allow retrying the same request up
+     * to the specified number of times, with the specified number of milliseconds of delay added to
+     * each additional attempt. For example, {@code 500} would cause the first retry to happen
+     * half a second later, the second retry one second later, the third one and a half seconds
+     * later, and so on.
+     *
+     * @param backoffScalar
+     *   The number of milliseconds to add to each retry attempt. The delay is cumulative, so each
+     *   retry takes longer than the previous one.
+     * @param maxRetryCount
+     *   The maximum number of times that the request can be retried.
+     */
+    public TransientFailureRetryStrategy(int backoffScalar, int maxRetryCount) {
+        super(backoffScalar, maxRetryCount);
     }
 
     @Override

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -101,7 +101,7 @@ public class PGPKeysServerClientIT {
     throws Exception {
         final int maxRetries = 2;
         final TransientFailureRetryStrategy retryStrategy
-            = new TransientFailureRetryStrategy(maxRetries);
+            = new TransientFailureRetryStrategy(100, maxRetries);
 
         // We use short timeouts for both timeouts since we don't want to hold up the tests on URLs
         // we know will take a while.

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -15,43 +15,195 @@
  */
 package org.simplify4u.plugins;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.InputStream;
-
-import com.google.common.io.ByteStreams;
-import org.testng.Assert;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.time.Duration;
+import java.time.Instant;
+import org.simplify4u.plugins.failurestrategies.TransientFailureRetryStrategy;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class PGPKeysServerClientIT {
-
     private static final long TEST_KEYID = 0xF8484389379ACEACL;
 
-    @DataProvider(name = "urlToTest")
-    Object[][] urlToTest() {
+    private static final int TEST_MAX_RETRIES = 10;
+    private static final int LONG_TEST_TIMEOUT = 30000;
+    private static final int SHORT_TEST_TIMEOUT = 1000;
+
+    @DataProvider(name = "goodServerUrls")
+    Object[][] goodServerUrls() {
         return new Object[][]{
-                {"hkp://pool.sks-keyservers.net"},
-                {"hkp://p80.pool.sks-keyservers.net:80"},
-                {"http://p80.pool.sks-keyservers.net"},
-                {"hkps://pgp.mit.edu/"},
-                {"hkps://hkps.pool.sks-keyservers.net"}
+            {"hkp://pool.sks-keyservers.net"},
+            {"hkp://p80.pool.sks-keyservers.net:80"},
+            {"http://p80.pool.sks-keyservers.net"},
+            {"hkps://pgp.mit.edu/"},
+            {"hkps://hkps.pool.sks-keyservers.net"}
         };
     }
 
-    @Test(dataProvider = "urlToTest", successPercentage = 80)
-    public void testClient(String keyServerUrl) throws Exception {
+    @DataProvider(name = "badServerUrls")
+    Object[][] badServerUrls() {
+        return new Object[][]{
+            {
+                "https://example.com:81",
+                "java.net.SocketTimeoutException: connect timed out",
+                true    // Should retry
+            },
+            {
+                "https://httpstat.us/200?sleep=10000",
+                "java.net.SocketTimeoutException: Read timed out",
+                true    // Should retry
+            },
+            {
+                "https://httpstat.us/502",
+                "java.io.IOException: Server returned HTTP response code: 502 for URL: "
+                + "https://httpstat.us/502",
+                true    // Should retry
+            },
+            {
+                "https://httpstat.us/404",
+                "java.io.FileNotFoundException: https://httpstat.us/404",
+                false    // Should not retry
+            }
+        };
+    }
 
-        File tempFile = File.createTempFile("PGPClientTest", null);
+    @Test(dataProvider = "goodServerUrls")
+    public void testClient(String keyServerUrl) throws Exception {
+        final File tempFile = File.createTempFile("PGPClientTest", null);
+
         tempFile.deleteOnExit();
 
-        PGPKeysServerClient pgpKeysServerClient = PGPKeysServerClient.getClient(keyServerUrl);
+        final PGPKeysServerClient client
+            = PGPKeysServerClient.getClient(keyServerUrl, SHORT_TEST_TIMEOUT, LONG_TEST_TIMEOUT);
 
-        try (InputStream inputStream = pgpKeysServerClient.getInputStreamForKey(TEST_KEYID);
-             FileOutputStream outputStream = new FileOutputStream(tempFile)) {
-            ByteStreams.copy(inputStream, outputStream);
+        try (FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+            client.copyKeyToOutputStream(TEST_KEYID, outputStream, new VerboseRetryStrategy());
         }
 
-        Assert.assertTrue(tempFile.length() > 0, "Download key is empty");
+        assertTrue(tempFile.length() > 0, "Downloaded key was not expected to be empty");
+    }
+
+    @Test(dataProvider = "badServerUrls")
+    public void testClientRetry(final String targetUrl,
+                                final String expectedExceptionString,
+                                final boolean shouldRetry)
+    throws Exception {
+        final int maxRetries = 2;
+        final TransientFailureRetryStrategy retryStrategy
+            = new TransientFailureRetryStrategy(maxRetries);
+
+        // We use short timeouts for both timeouts since we don't want to hold up the tests on URLs
+        // we know will take a while.
+        final PGPKeysServerClient client
+            = new StubbedClient(new URI(targetUrl), SHORT_TEST_TIMEOUT, SHORT_TEST_TIMEOUT);
+
+        IOException caughtException = null;
+
+        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            client.copyKeyToOutputStream(TEST_KEYID, outputStream, retryStrategy);
+
+            System.out.println(new String(outputStream.toByteArray()));
+        } catch (IOException ex) {
+            caughtException = ex;
+        }
+
+        assertNotNull(caughtException);
+        assertEquals(caughtException.toString(), expectedExceptionString);
+
+        if (shouldRetry) {
+            assertEquals(retryStrategy.getCurrentRetryCount(), maxRetries);
+        } else {
+            assertEquals(retryStrategy.getCurrentRetryCount(), 0);
+        }
+    }
+
+    /**
+     * This retry strategy is used for tests against real key servers.
+     *
+     * <p>This extends the normal transient failure retry strategy to provide additional output to
+     * standard error when a key server is triggering a retry, since this should be a rare event --
+     * unless the server is unreliable. The additional output is intended to help nail down the
+     * issue.
+     */
+    private static class VerboseRetryStrategy
+    extends TransientFailureRetryStrategy {
+        private Instant lastRetryStart;
+
+        VerboseRetryStrategy() {
+            super(TEST_MAX_RETRIES);
+
+            this.resetTimer();
+        }
+
+        @Override
+        public void onRetry(URL url, IOException cause) {
+            super.onRetry(url, cause);
+
+            System.err.println(
+                String.format(
+                    "[Retry %d of %d] Attempting key request from %s after error "
+                    + "(failed after %d seconds): \"%s\"",
+                    this.getCurrentRetryCount(),
+                    this.getMaxRetryCount(),
+                    url,
+                    this.getSecondsSinceLastRetry(),
+                    cause.toString()));
+
+            this.resetTimer();
+        }
+
+        private void resetTimer() {
+            this.lastRetryStart = Instant.now();
+        }
+
+        private long getSecondsSinceLastRetry() {
+            final Instant now = Instant.now();
+
+            return Duration.between(this.lastRetryStart, now).toMillis() / 1000;
+        }
+    }
+
+    /**
+     * A special key client that allows the URL the client is requesting to be stubbed-out by tests.
+     *
+     * <p>This is used by tests that are testing retry behavior, to allow them to control exactly
+     * which URL is being requested. Each URL provided by tests simulates a different type of
+     * failure.
+     */
+    private static class StubbedClient
+    extends PGPKeysServerClientHttps {
+        private final URI stubbedUri;
+
+        StubbedClient(final URI stubbedUri, final int connectTimeout, final int readTimeout)
+        throws CertificateException, NoSuchAlgorithmException, IOException, KeyManagementException,
+               KeyStoreException, URISyntaxException {
+            super(stubbedUri, connectTimeout, readTimeout);
+
+            this.stubbedUri = stubbedUri;
+        }
+
+        @Override
+        URI getUriForShowKey(long keyID) {
+            return this.stubbedUri;
+        }
+
+        @Override
+        URI getUriForGetKey(long keyID) {
+            return this.stubbedUri;
+        }
     }
 }

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -79,7 +79,7 @@ public class PGPKeysServerClientIT {
         };
     }
 
-    @Test(dataProvider = "goodServerUrls")
+    @Test(dataProvider = "goodServerUrls", successPercentage = 80)
     public void testClient(String keyServerUrl) throws Exception {
         final File tempFile = File.createTempFile("PGPClientTest", null);
 

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -32,8 +32,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.time.Duration;
-import java.time.Instant;
+import java.util.Date;
 import org.simplify4u.plugins.failurestrategies.TransientFailureRetryStrategy;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -140,7 +139,7 @@ public class PGPKeysServerClientIT {
      */
     private static class VerboseRetryStrategy
     extends TransientFailureRetryStrategy {
-        private Instant lastRetryStart;
+        private Date lastRetryStart;
 
         VerboseRetryStrategy() {
             super();
@@ -194,13 +193,13 @@ public class PGPKeysServerClientIT {
         }
 
         private void resetTimer() {
-            this.lastRetryStart = Instant.now();
+            this.lastRetryStart = new Date();
         }
 
         private long getSecondsSinceLastRetry() {
-            final Instant now = Instant.now();
+            final Date now = new Date();
 
-            return Duration.between(this.lastRetryStart, now).toMillis() / 1000;
+            return (now.getTime() - this.lastRetryStart.getTime()) / 1000;
         }
     }
 

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -23,9 +23,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -153,14 +155,30 @@ public class PGPKeysServerClientIT {
             System.err.println(
                 String.format(
                     "[Retry %d of %d] Attempting key request from %s after error "
-                    + "(failed after %d seconds): \"%s\"",
+                    + "(failed after %d seconds, target host was %s): \"%s\"",
                     this.getCurrentRetryCount(),
                     this.getMaxRetryCount(),
                     url,
                     this.getSecondsSinceLastRetry(),
+                    this.getTargetHost(url),
                     cause.toString()));
 
             this.resetTimer();
+        }
+
+        private String getTargetHost(URL url) {
+            String ipAddress;
+
+            final InetAddress address;
+            try {
+                address = InetAddress.getByName(url.getHost());
+                ipAddress = address.toString();
+            } catch (UnknownHostException ex) {
+                // Suppress -- fall back to "unknown".
+                ipAddress = "unknown";
+            }
+
+            return ipAddress;
         }
 
         @Override

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -39,8 +39,6 @@ import org.testng.annotations.Test;
 public class PGPKeysServerClientIT {
     private static final long TEST_KEYID = 0xF8484389379ACEACL;
 
-    private static final int TEST_MAX_RETRIES = 10;
-    private static final int LONG_TEST_TIMEOUT = 30000;
     private static final int SHORT_TEST_TIMEOUT = 1000;
 
     @DataProvider(name = "goodServerUrls")
@@ -87,8 +85,7 @@ public class PGPKeysServerClientIT {
 
         tempFile.deleteOnExit();
 
-        final PGPKeysServerClient client
-            = PGPKeysServerClient.getClient(keyServerUrl, SHORT_TEST_TIMEOUT, LONG_TEST_TIMEOUT);
+        final PGPKeysServerClient client = PGPKeysServerClient.getClient(keyServerUrl);
 
         try (FileOutputStream outputStream = new FileOutputStream(tempFile)) {
             client.copyKeyToOutputStream(TEST_KEYID, outputStream, new VerboseRetryStrategy());
@@ -144,7 +141,7 @@ public class PGPKeysServerClientIT {
         private Instant lastRetryStart;
 
         VerboseRetryStrategy() {
-            super(TEST_MAX_RETRIES);
+            super();
 
             this.resetTimer();
         }

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -166,6 +166,18 @@ public class PGPKeysServerClientIT {
             this.resetTimer();
         }
 
+        @Override
+        public void onBackoff(final URL url, final long delay) {
+            super.onBackoff(url, delay);
+
+            System.err.println(
+                String.format(
+                    "[Retry %d of %d] Backing off for %d milliseconds...",
+                    this.getCurrentRetryCount(),
+                    this.getMaxRetryCount(),
+                    delay));
+        }
+
         private void resetTimer() {
             this.lastRetryStart = Instant.now();
         }


### PR DESCRIPTION
- Modifies the HTTP and HTTPS PGP clients to support a failure strategy, which controls how the clients handle failed requests.
- Implements a strategy that is used by the rest of the plug-in to allow recovery on transient 5XX errors, connection timeouts, and read timeouts.
- Sets the default timeouts to:
  - 5 seconds to connect to the target server
  - 20 seconds to read the key from the server
- Uses a back-off strategy of +2000 ms per retry attempt. So if the max retries is `3`, then:
  - First retry happens after 2000 ms.
  - Second retry happens after 4000 ms.
  - Third retry happens after 6000 ms.

Timeouts are not yet user-configurable, but can be made configurable at a later time should the need arise.

Closes #34.