### PR TITLE
Re-factor PGP Client to Use Apache HTTP and Automatic Retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
                 <artifactId>plexus-resources</artifactId>
                 <version>1.0.1</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.5</version>
+            </dependency>
 
             <!-- dependency coverage -->
             <dependency>
@@ -147,6 +152,10 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpg-jdk15on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/org/simplify4u/plugins/NullLogger.java
+++ b/src/main/java/org/simplify4u/plugins/NullLogger.java
@@ -1,0 +1,88 @@
+package org.simplify4u.plugins;
+
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * A logger that does not actually log anything.
+ */
+public class NullLogger implements Log {
+    @Override
+    public boolean isDebugEnabled() {
+        return false;
+    }
+
+    @Override
+    public void debug(CharSequence charSequence) {
+        // No op
+    }
+
+    @Override
+    public void debug(CharSequence charSequence, Throwable throwable) {
+        // No op
+    }
+
+    @Override
+    public void debug(Throwable throwable) {
+        // No op
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return false;
+    }
+
+    @Override
+    public void info(CharSequence charSequence) {
+        // No op
+    }
+
+    @Override
+    public void info(CharSequence charSequence, Throwable throwable) {
+        // No op
+    }
+
+    @Override
+    public void info(Throwable throwable) {
+        // No op
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return false;
+    }
+
+    @Override
+    public void warn(CharSequence charSequence) {
+        // No op
+    }
+
+    @Override
+    public void warn(CharSequence charSequence, Throwable throwable) {
+        // No op
+    }
+
+    @Override
+    public void warn(Throwable throwable) {
+        // No op
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return false;
+    }
+
+    @Override
+    public void error(CharSequence charSequence) {
+        // No op
+    }
+
+    @Override
+    public void error(CharSequence charSequence, Throwable throwable) {
+        // No op
+    }
+
+    @Override
+    public void error(Throwable throwable) {
+        // No op
+    }
+}

--- a/src/main/java/org/simplify4u/plugins/NullLogger.java
+++ b/src/main/java/org/simplify4u/plugins/NullLogger.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Wren Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.simplify4u.plugins;
 
 import org.apache.maven.plugin.logging.Log;

--- a/src/main/java/org/simplify4u/plugins/PGPKeysServerClient.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysServerClient.java
@@ -42,7 +42,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
  */
 abstract class PGPKeysServerClient {
     private static final int DEFAULT_CONNECT_TIMEOUT = 5000;
-    private static final int DEFAULT_READ_TIMEOUT = 10000;
+    private static final int DEFAULT_READ_TIMEOUT = 20000;
 
     private final URI keyserver;
     private final int connectTimeout;

--- a/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttp.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttp.java
@@ -15,35 +15,36 @@
  */
 package org.simplify4u.plugins;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 /**
  * Implementation of PGPKeysServerClient for HTTP protocol.
  */
 class PGPKeysServerClientHttp extends PGPKeysServerClient {
-
-    protected PGPKeysServerClientHttp(URI keyserver) throws URISyntaxException {
-        super(keyserver);
+    protected PGPKeysServerClientHttp(final URI keyserver, final int connectTimeout,
+                                      final int readTimeout)
+    throws URISyntaxException {
+        super(keyserver, connectTimeout, readTimeout);
     }
 
     @Override
-    protected URI prepareKeyServerURI(URI keyserver) throws URISyntaxException {
-
+    protected URI prepareKeyServerURI(URI keyServer) throws URISyntaxException {
         int port = -1;
-        if (keyserver.getPort() > 0) {
-            port = keyserver.getPort();
-        } else if ("hkp".equalsIgnoreCase(keyserver.getScheme())) {
+
+        if (keyServer.getPort() > 0) {
+            port = keyServer.getPort();
+        } else if ("hkp".equalsIgnoreCase(keyServer.getScheme())) {
             port = 11371;
         }
-        return new URI("http", keyserver.getUserInfo(), keyserver.getHost(), port, null, null, null);
+
+        return new URI(
+            "http", keyServer.getUserInfo(), keyServer.getHost(), port, null, null, null);
     }
 
     @Override
-    protected InputStream getInputStreamForKey(URL keyURL) throws IOException {
-        return keyURL.openStream();
+    protected HttpClientBuilder createClientBuilder() {
+         return HttpClientBuilder.create();
     }
 }

--- a/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttp.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttp.java
@@ -20,7 +20,7 @@ import java.net.URISyntaxException;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 /**
- * Implementation of PGPKeysServerClient for HTTP protocol.
+ * Implementation of a client for requesting keys from PGP key servers over HKP/HTTP.
  */
 class PGPKeysServerClientHttp extends PGPKeysServerClient {
     protected PGPKeysServerClientHttp(final URI keyserver, final int connectTimeout,

--- a/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttps.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttps.java
@@ -15,15 +15,9 @@
  */
 package org.simplify4u.plugins;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -31,46 +25,64 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 
 /**
  * Implementation of PGPKeysServerClient for HTTPS protocol.
  */
 public class PGPKeysServerClientHttps extends PGPKeysServerClient {
 
-    private final SSLSocketFactory sslSocketFactory;
+    private final SSLConnectionSocketFactory sslSocketFactory;
 
-    protected PGPKeysServerClientHttps(URI uri)
-            throws URISyntaxException, CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
-        super(uri);
-        if ("hkps.pool.sks-keyservers.net".equalsIgnoreCase(uri.getHost())) {
+    protected PGPKeysServerClientHttps(final URI uri, final int connectTimeout,
+                                       final int readTimeout)
+    throws URISyntaxException, CertificateException, IOException, KeyStoreException,
+           NoSuchAlgorithmException, KeyManagementException {
+        super(uri, connectTimeout, readTimeout);
+
+        if (uri.getHost().toLowerCase().endsWith("sks-keyservers.net")) {
             final CertificateFactory cf = CertificateFactory.getInstance("X.509");
-            final Certificate ca = cf.generateCertificate(getClass().getClassLoader().getResourceAsStream("sks-keyservers.netCA.pem"));
+            final Certificate ca = cf.generateCertificate(
+                getClass().getClassLoader().getResourceAsStream("sks-keyservers.netCA.pem"));
+
             final KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+
             keyStore.load(null, null);
             keyStore.setCertificateEntry("ca", ca);
 
-            final TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            final TrustManagerFactory tmf
+                = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             tmf.init(keyStore);
 
             final SSLContext context = SSLContext.getInstance("TLS");
             context.init(null, tmf.getTrustManagers(), null);
 
-            this.sslSocketFactory = context.getSocketFactory();
+            this.sslSocketFactory
+                = new SSLConnectionSocketFactory(
+                    context, SSLConnectionSocketFactory.getDefaultHostnameVerifier());
         } else {
-            this.sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+            this.sslSocketFactory = SSLConnectionSocketFactory.getSystemSocketFactory();
         }
     }
 
     @Override
     protected URI prepareKeyServerURI(URI keyserver) throws URISyntaxException {
-        return new URI("https", keyserver.getUserInfo(), keyserver.getHost(), keyserver.getPort(), null, null, null);
+        return new URI(
+            "https",
+            keyserver.getUserInfo(),
+            keyserver.getHost(),
+            keyserver.getPort(),
+            null,
+            null,
+            null);
     }
 
     @Override
-    protected InputStream getInputStreamForKey(URL keyURL) throws IOException {
-        // standard support by Java - can be extended eg. to support custom CA certs
-        final HttpsURLConnection keyServerUrlConnection = (HttpsURLConnection) keyURL.openConnection();
-        keyServerUrlConnection.setSSLSocketFactory(sslSocketFactory);
-        return keyServerUrlConnection.getInputStream();
+    protected HttpClientBuilder createClientBuilder() {
+        return HttpClients.custom().setSSLSocketFactory(this.sslSocketFactory);
     }
 }

--- a/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttps.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysServerClientHttps.java
@@ -32,10 +32,9 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
 /**
- * Implementation of PGPKeysServerClient for HTTPS protocol.
+ * Implementation of a client for requesting keys from PGP key servers over HKPS/HTTPS.
  */
 public class PGPKeysServerClientHttps extends PGPKeysServerClient {
-
     private final SSLConnectionSocketFactory sslSocketFactory;
 
     protected PGPKeysServerClientHttps(final URI uri, final int connectTimeout,

--- a/src/main/java/org/simplify4u/plugins/PGPServerRetryHandler.java
+++ b/src/main/java/org/simplify4u/plugins/PGPServerRetryHandler.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2018 Wren Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.simplify4u.plugins;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import javax.net.ssl.SSLException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.apache.http.util.Args;
+import org.apache.maven.plugin.logging.Log;
+
+public class PGPServerRetryHandler
+implements HttpRequestRetryHandler, ServiceUnavailableRetryStrategy {
+    public static final int DEFAULT_MAX_RETRIES = 10;
+    public static final int DEFAULT_BACKOFF_INTERVAL = 750;
+
+    @SuppressWarnings("unchecked")
+    private static final List<Class<? extends IOException>> IGNORED_EXCEPTIONS =
+        (List) Collections.singletonList(SSLException.class);
+
+    /**
+     * The list of HTTP status codes that signal request failures that may be recoverable after
+     * a retry.
+     */
+    private static final List<Integer> RETRYABLE_STATUS_CODES =
+        ImmutableList.of(
+            HttpStatus.SC_REQUEST_TIMEOUT,
+            HttpStatus.SC_INTERNAL_SERVER_ERROR,
+            HttpStatus.SC_BAD_GATEWAY,
+            HttpStatus.SC_SERVICE_UNAVAILABLE,
+            HttpStatus.SC_GATEWAY_TIMEOUT
+        );
+
+    private final HttpRequestRetryHandler requestRetryHandler;
+    private final ServiceUnavailableRetryStrategy serviceRetryHandler;
+    private final Log logger;
+
+    private int currentRetryCount;
+
+    public PGPServerRetryHandler() {
+        this(new NullLogger(), DEFAULT_MAX_RETRIES, DEFAULT_BACKOFF_INTERVAL);
+    }
+
+    public PGPServerRetryHandler(final Log logger) {
+        this(logger, DEFAULT_MAX_RETRIES, DEFAULT_BACKOFF_INTERVAL);
+    }
+
+    public PGPServerRetryHandler(int maxRetries) {
+        this(new NullLogger(), maxRetries, DEFAULT_BACKOFF_INTERVAL);
+    }
+
+    public PGPServerRetryHandler(final Log logger, final int maxRetries,
+                                 final long unavailableBackoffInterval) {
+        this.requestRetryHandler = new RequestRetryStrategy(maxRetries);
+        this.serviceRetryHandler = new ServiceRetryStrategy(maxRetries, unavailableBackoffInterval);
+        this.logger = logger;
+
+        this.currentRetryCount = 0;
+    }
+
+    public int getCurrentRetryCount() {
+        return this.currentRetryCount;
+    }
+
+    @Override
+    public boolean retryRequest(final IOException cause,
+                                final int executionCount,
+                                final HttpContext context) {
+        final boolean shouldRetry
+            = this.requestRetryHandler.retryRequest(cause, executionCount, context);
+
+        this.dispatchRetry(shouldRetry, cause.toString(), context);
+
+        return shouldRetry;
+    }
+
+    @Override
+    public boolean retryRequest(final HttpResponse response, final int executionCount,
+                                final HttpContext context) {
+        final boolean shouldRetry
+            = this.serviceRetryHandler.retryRequest(response, executionCount, context);
+
+        this.dispatchRetry(shouldRetry, response.getStatusLine().toString(), context);
+
+        return shouldRetry;
+    }
+
+    @Override
+    public long getRetryInterval() {
+        return this.serviceRetryHandler.getRetryInterval();
+    }
+
+    protected void onRetry(final String retryReason, final int retryCount,
+                           final HttpContext context) {
+        this.logRetry(retryReason, retryCount, context);
+    }
+
+    private void dispatchRetry(boolean shouldRetry, String retryReason, HttpContext context) {
+        if (shouldRetry) {
+            ++this.currentRetryCount;
+
+            this.onRetry(retryReason, this.currentRetryCount, context);
+        }
+    }
+
+    private void logRetry(String retryReason, int executionCount, HttpContext context) {
+        final HttpHost host = (HttpHost) context.getAttribute(HttpCoreContext.HTTP_TARGET_HOST);
+
+        logger.warn(
+            String.format(
+                "[Retry %d of %d] Attempting key request from %s after previous request failed: "
+                + "\"%s\"",
+                executionCount,
+                this.getCurrentRetryCount(),
+                host.getAddress(),
+                retryReason));
+    }
+
+    private static class RequestRetryStrategy
+    extends DefaultHttpRequestRetryHandler {
+        RequestRetryStrategy(final int maxRetries) {
+            super(maxRetries, false, IGNORED_EXCEPTIONS);
+        }
+    }
+
+    private class ServiceRetryStrategy
+    implements ServiceUnavailableRetryStrategy {
+        /**
+         * Maximum number of allowed retries if the server responds with a HTTP code
+         * in our retry code list. Default value is 1.
+         */
+        private final int maxRetries;
+
+        /**
+         * The number of milliseconds to add to each retry attempt. The delay is cumulative, so each
+         * retry takes longer than the previous one.
+         */
+        private final long backoffScalar;
+
+        ServiceRetryStrategy(final int maxRetries, final long backoffScalar) {
+            super();
+
+            Args.positive(maxRetries, "Max retries");
+            Args.positive(backoffScalar, "Back-off scalar interval");
+
+            this.maxRetries = maxRetries;
+            this.backoffScalar = backoffScalar;
+        }
+
+        @Override
+        public boolean retryRequest(final HttpResponse response, final int executionCount,
+                                    final HttpContext context) {
+            final boolean shouldRetry
+                = executionCount <= maxRetries
+                && RETRYABLE_STATUS_CODES.contains(response.getStatusLine().getStatusCode());
+
+            return shouldRetry;
+        }
+
+        @Override
+        public long getRetryInterval() {
+            return PGPServerRetryHandler.this.currentRetryCount * this.backoffScalar;
+        }
+    }
+}

--- a/src/main/java/org/simplify4u/plugins/PGPServerRetryHandler.java
+++ b/src/main/java/org/simplify4u/plugins/PGPServerRetryHandler.java
@@ -35,34 +35,114 @@ import org.apache.http.protocol.HttpCoreContext;
 import org.apache.http.util.Args;
 import org.apache.maven.plugin.logging.Log;
 
+/**
+ * The primary handler for retry logic in HKP/HTTP and HKPS/HTTPS clients in this plug-in.
+ *
+ * <p>This handler is a composite of the following two interfaces:
+ * <ul>
+ *     <li>A {@link HttpRequestRetryHandler}, which controls how retries are handled for service
+ *     reach-ability (e.g. connection timeouts, connection drops).</li>
+ *     <li>A {@link ServiceUnavailableRetryStrategy}, which controls how retries are handled for
+ *     service load issues (e.g. internal server errors, load balancer errors, read timeouts,
+ *     etc).</li>
+ * </ul>
+ *
+ * <p>The handler unifies the two interfaces, providing a single injection point for logging and
+ * retry handling.
+ */
 public class PGPServerRetryHandler
 implements HttpRequestRetryHandler, ServiceUnavailableRetryStrategy {
+    /**
+     * The maximum number of retry attempts that either handler will make before giving up.
+     *
+     * <p>This default applies to each type of handler. This means that if both are configured with
+     * the default value, then it is conceivable that the same request could hypothetically be
+     * retried up to 20 times (10 times for connection issues, then 10 times upon connecting and
+     * repeatedly receiving a bad HTTP response).
+     */
     public static final int DEFAULT_MAX_RETRIES = 10;
+
+    /**
+     * The amount of time added to each additional retry attempt.
+     *
+     * <p>The interval is additive. For example, if there are three retry attempts, the first will
+     * occur after 750 milliseconds; the second will occur after 1,500 milliseconds; and the third
+     * will occur after 2,250 milliseconds.
+     */
     public static final int DEFAULT_BACKOFF_INTERVAL = 750;
 
     private final RequestRetryStrategy requestRetryHandler;
     private final ServiceRetryStrategy serviceRetryHandler;
     private final Log logger;
 
+    /**
+     * Default constructor for {@code PGPServerRetryHandler}.
+     *
+     * <p>The handler is constructed to perform up to {@link #DEFAULT_MAX_RETRIES} retries, backing
+     * off an additional {@link #DEFAULT_BACKOFF_INTERVAL}milliseconds in between each attempt;
+     * without any logging output.
+     */
     public PGPServerRetryHandler() {
-        this(new NullLogger(), DEFAULT_MAX_RETRIES, DEFAULT_BACKOFF_INTERVAL);
+        this(DEFAULT_MAX_RETRIES);
     }
 
+    /**
+     * Constructor for a {@code PGPServerRetryHandler} that writes to the given logger.
+     *
+     * <p>The handler is constructed to perform up to {@link #DEFAULT_MAX_RETRIES} retries, backing
+     * off an additional {@link #DEFAULT_BACKOFF_INTERVAL}milliseconds in between each attempt.
+     * Warnings are written out to the logger whenever retries are being attempted.
+     *
+     * @param logger
+     *   The logger to which output will be written.
+     */
     public PGPServerRetryHandler(final Log logger) {
         this(logger, DEFAULT_MAX_RETRIES, DEFAULT_BACKOFF_INTERVAL);
     }
 
+    /**
+     * Constructor for a {@code PGPServerRetryHandler} that performs up to a set number of retries.
+     *
+     * <p>The handler is constructed to perform up to {@code maxRetries} retries, backing off an
+     * additional {@link #DEFAULT_BACKOFF_INTERVAL}milliseconds in between each attempt; without any
+     * logging output.
+     *
+     * @param maxRetries
+     *   The maximum number of times to retry on service reach-ability or server load issues.
+     */
     public PGPServerRetryHandler(int maxRetries) {
         this(new NullLogger(), maxRetries, DEFAULT_BACKOFF_INTERVAL);
     }
 
+    /**
+     * Constructor for a {@code PGPServerRetryHandler} that performs up to a set number of retries
+     * and writes to the given logger.
+     *
+     * <p>The handler is constructed to perform up to {@code maxRetries} retries, backing off an
+     * additional {@code backoffInterval} milliseconds in between each attempt. Warnings are written
+     * out to the logger whenever retries are being attempted.
+     *
+     * @param logger
+     *   The logger to which output will be written.
+     * @param maxRetries
+     *   The maximum number of times to retry on service reach-ability or server load issues.
+     * @param backoffInterval
+     *   The additional number of milliseconds of delay to add to each additional retry attempt.
+     */
     public PGPServerRetryHandler(final Log logger, final int maxRetries,
-                                 final long unavailableBackoffInterval) {
+                                 final long backoffInterval) {
         this.requestRetryHandler = new RequestRetryStrategy(maxRetries);
-        this.serviceRetryHandler = new ServiceRetryStrategy(maxRetries, unavailableBackoffInterval);
+        this.serviceRetryHandler = new ServiceRetryStrategy(maxRetries, backoffInterval);
         this.logger = logger;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Unlike the default Apache implementation of this method, this handler enforces a back-off
+     * delay before allowing the retry to proceed. This helps to ensure that PGP servers are given
+     * an opportunity to recover from server-side load issues.
+     */
     @Override
     public boolean retryRequest(final IOException cause,
                                 final int executionCount,
@@ -112,30 +192,76 @@ implements HttpRequestRetryHandler, ServiceUnavailableRetryStrategy {
         return this.serviceRetryHandler.getRetryInterval();
     }
 
+    /**
+     * An injection point for sub-classes to invoke their own logic each time a retry is attempted.
+     *
+     * @param retryReason
+     *   A human-friendly description of the reason for why the retry is being attempted.
+     * @param retryCount
+     *   A count of the number of retries that have been attempted. The value is one-based, so the
+     *   first retry has a {@code retryCount} of {@code 1}.
+     * @param backoffDelay
+     *   The total number of milliseconds that the client will delay before the retry attempt
+     *   will occur. This method is invoked just prior to the start of this interval.
+     * @param requestContext
+     *   Client context about the prior, failed request that was previously attempted.
+     */
     protected void onRetry(final String retryReason, final int retryCount,
                            final long backoffDelay, final HttpContext requestContext) {
         // No-op -- provided for sub-classes to override
     }
 
+    /**
+     * Dispatch the appropriate events to sub-classes and the logger if a try should be attempted.
+     *
+     * @param shouldRetry
+     *   Whether or not the underlying handler indicated that a retry should be attempted.
+     * @param retryReason
+     *   A human-friendly description of the reason for why the retry is being attempted.
+     * @param retryCount
+     *   A count of the number of retries that have been attempted. The value is one-based, so the
+     *   first retry has a {@code retryCount} of {@code 1}.
+     * @param backoffDelay
+     *   The total number of milliseconds that the client will delay before the retry attempt
+     *   will occur. This method is invoked just prior to the start of this interval.
+     * @param requestContext
+     *   Client context about the prior, failed request that was previously attempted.
+     */
     private void dispatchRetry(boolean shouldRetry, final String retryReason,
-                               final int executionCount, final long backoffDelay,
+                               final int retryCount, final long backoffDelay,
                                final HttpContext requestContext) {
         if (shouldRetry) {
-            this.logRetry(retryReason, executionCount, backoffDelay, requestContext);
-            this.onRetry(retryReason, executionCount, backoffDelay, requestContext);
+            this.logRetry(retryReason, retryCount, backoffDelay, requestContext);
+            this.onRetry(retryReason, retryCount, backoffDelay, requestContext);
         }
     }
 
-    private void logRetry(final String retryReason, final int executionCount,
-                          final long backoffDelay, final HttpContext context) {
-        final HttpHost host = (HttpHost) context.getAttribute(HttpCoreContext.HTTP_TARGET_HOST);
+    /**
+     * Write a warning to the logger that includes information about a request is about to be
+     * retried.
+     *
+     * @param retryReason
+     *   A human-friendly description of the reason for why the retry is being attempted.
+     * @param retryCount
+     *   A count of the number of retries that have been attempted. The value is one-based, so the
+     *   first retry has a {@code retryCount} of {@code 1}.
+     * @param backoffDelay
+     *   The total number of milliseconds that the client will delay before the retry attempt
+     *   will occur. This method is invoked just prior to the start of this interval.
+     * @param requestContext
+     *   Client context about the prior, failed request that was previously attempted.
+     */
+    private void logRetry(final String retryReason, final int retryCount,
+                          final long backoffDelay, final HttpContext requestContext) {
+        final HttpHost host =
+            (HttpHost) requestContext.getAttribute(HttpCoreContext.HTTP_TARGET_HOST);
 
         if (logger.isWarnEnabled()) {
             logger.warn(
                 String.format(
                     "[Retry %d of %d] Waiting %d milliseconds before retrying key request from %s "
                     + "after last request failed: %s",
-                    executionCount,
+                    retryCount,
                     this.requestRetryHandler.getRetryCount(),
                     backoffDelay,
                     describeHost(host),
@@ -143,6 +269,16 @@ implements HttpRequestRetryHandler, ServiceUnavailableRetryStrategy {
         }
     }
 
+    /**
+     * Convert an Apache HTTP host object to a human-readable, loggable description of the host.
+     *
+     * @param host
+     *   The host to convert to loggable output.
+     *
+     * @return
+     *   The human-readable, loggable description of the host, including the hostname and IP
+     *   address.
+     */
     private String describeHost(final HttpHost host) {
         String description;
 
@@ -162,17 +298,42 @@ implements HttpRequestRetryHandler, ServiceUnavailableRetryStrategy {
         return description;
     }
 
+    /**
+     * The inner request retry strategy that the outer class wraps.
+     *
+     * <p>This controls how retries are handled for service reach-ability (e.g. connection
+     * timeouts, connection drops). It is invoked whenever a connection cannot be established or is
+     * dropped, without a complete response.
+     */
     private static class RequestRetryStrategy
     extends DefaultHttpRequestRetryHandler {
+        /**
+         * The types of HTTP exceptions that are not worth retrying.
+         */
         @SuppressWarnings("unchecked")
         private static final List<Class<? extends IOException>> IGNORED_EXCEPTIONS =
             (List) Collections.singletonList(SSLException.class);
 
+        /**
+         * Constructor for {@code RequestRetryStrategy}.
+         *
+         * @param maxRetries
+         *   The maximum number of times to retry connecting to a service.
+         */
         RequestRetryStrategy(final int maxRetries) {
             super(maxRetries, false, IGNORED_EXCEPTIONS);
+
+            Args.positive(maxRetries, "Max retries");
         }
     }
 
+    /**
+     * The inner service retry strategy that the outer class wraps.
+     *
+     * <p>This controls how retries are handled for service load issues (e.g. internal server
+     * errors, load balancer errors, read timeouts, etc). This handler is invoked when there has
+     * been an unsuccessful response returned by the target server.
+     */
     private static class ServiceRetryStrategy
     implements ServiceUnavailableRetryStrategy {
         /**
@@ -190,13 +351,13 @@ implements HttpRequestRetryHandler, ServiceUnavailableRetryStrategy {
 
         /**
          * Maximum number of allowed retries if the server responds with a HTTP code
-         * in our retry code list. Default value is 1.
+         * in our retry code list.
          */
         private final int maxRetries;
 
         /**
          * The number of milliseconds to add to each retry attempt. The delay is cumulative, so each
-         * retry takes longer than the previous one.
+         * retry takes this much longer than the previous one.
          */
         private final long backoffScalar;
 
@@ -205,6 +366,16 @@ implements HttpRequestRetryHandler, ServiceUnavailableRetryStrategy {
          */
         private final AtomicLong currentRetryCount;
 
+        /**
+         * Constructor for {@code ServiceRetryStrategy}.
+         *
+         * @param maxRetries
+         *   The maximum number of allowed retries if the server responds with a HTTP code in our
+         *   retry code list.
+         * @param backoffScalar
+         *   The number of milliseconds to add to each retry attempt. The delay is cumulative, so
+         *   each retry takes this much longer than the previous one.
+         */
         ServiceRetryStrategy(final int maxRetries, final long backoffScalar) {
             super();
 
@@ -216,8 +387,15 @@ implements HttpRequestRetryHandler, ServiceUnavailableRetryStrategy {
             this.currentRetryCount = new AtomicLong(0);
         }
 
+        /**
+         * Get the number of milliseconds to add to each retry attempt. The delay is cumulative, so
+         * each retry should takes this much longer than the previous one.
+         *
+         * @return
+         *   The number of milliseconds to add to each retry request.
+         */
         public long getBackoffScalar() {
-            return backoffScalar;
+            return this.backoffScalar;
         }
 
         @Override
@@ -234,6 +412,14 @@ implements HttpRequestRetryHandler, ServiceUnavailableRetryStrategy {
             return shouldRetry;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * <p>The interval is cumulative, so each retry attempt should take longer than the previous
+         * one.
+         *
+         * @see #getBackoffScalar()
+         */
         @Override
         public long getRetryInterval() {
             return this.currentRetryCount.get() * this.backoffScalar;

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -15,43 +15,165 @@
  */
 package org.simplify4u.plugins;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.InputStream;
-
-import com.google.common.io.ByteStreams;
-import org.testng.Assert;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.http.protocol.HttpContext;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class PGPKeysServerClientIT {
-
     private static final long TEST_KEYID = 0xF8484389379ACEACL;
 
-    @DataProvider(name = "urlToTest")
-    Object[][] urlToTest() {
+    private static final int MAX_TEST_RETRIES = 10;
+    private static final int SHORT_TEST_TIMEOUT = 1000;
+
+    @DataProvider(name = "goodServerUrls")
+    Object[][] goodServerUrls() {
         return new Object[][]{
-                {"hkp://pool.sks-keyservers.net"},
-                {"hkp://p80.pool.sks-keyservers.net:80"},
-                {"http://p80.pool.sks-keyservers.net"},
-                {"hkps://pgp.mit.edu/"},
-                {"hkps://hkps.pool.sks-keyservers.net"}
+            {"hkp://pool.sks-keyservers.net"},
+            {"hkp://p80.pool.sks-keyservers.net:80"},
+            {"http://p80.pool.sks-keyservers.net"},
+            {"hkps://pgp.mit.edu/"},
+            {"hkps://hkps.pool.sks-keyservers.net"}
         };
     }
 
-    @Test(dataProvider = "urlToTest", successPercentage = 80)
-    public void testClient(String keyServerUrl) throws Exception {
+    @DataProvider(name = "badServerUrls")
+    Object[][] badServerUrls() {
+        return new Object[][]{
+            {
+                "https://example.com:81",
+                "org.apache.http.conn.ConnectTimeoutException: Connect to example.com:81 "
+                + "[example.com/93.184.216.34] failed: connect timed out",
+                true    // Should retry
+            },
+            {
+                "https://httpstat.us/200?sleep=10000",
+                "java.net.SocketTimeoutException: Read timed out",
+                true    // Should retry
+            },
+            {
+                "https://httpstat.us/502",
+                "java.io.IOException: PGP server returned an error: HTTP/1.1 502 Bad Gateway",
+                true    // Should retry
+            },
+            {
+                "https://httpstat.us/404",
+                "java.io.IOException: PGP server returned an error: HTTP/1.1 404 Not Found",
+                false    // Should not retry
+            }
+        };
+    }
 
-        File tempFile = File.createTempFile("PGPClientTest", null);
+    @BeforeClass
+    public void suppressApacheLogging() {
+        System.setProperty(
+            "org.apache.commons.logging.Log",
+            "org.apache.commons.logging.impl.SimpleLog");
+
+        System.setProperty(
+            "org.apache.commons.logging.simplelog.log.org.apache.http",
+            "ERROR");
+    }
+
+    @Test(dataProvider = "goodServerUrls")
+    public void testClient(String keyServerUrl) throws Exception {
+        final File tempFile = File.createTempFile("PGPClientTest", null);
+
         tempFile.deleteOnExit();
 
-        PGPKeysServerClient pgpKeysServerClient = PGPKeysServerClient.getClient(keyServerUrl);
+        final PGPKeysServerClient client = PGPKeysServerClient.getClient(keyServerUrl);
 
-        try (InputStream inputStream = pgpKeysServerClient.getInputStreamForKey(TEST_KEYID);
-             FileOutputStream outputStream = new FileOutputStream(tempFile)) {
-            ByteStreams.copy(inputStream, outputStream);
+        try (FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+            client.copyKeyToOutputStream(
+                TEST_KEYID, outputStream, new PGPServerRetryHandler(MAX_TEST_RETRIES));
         }
 
-        Assert.assertTrue(tempFile.length() > 0, "Download key is empty");
+        assertTrue(tempFile.length() > 0, "Downloaded key was not expected to be empty");
+    }
+
+    @Test(dataProvider = "badServerUrls")
+    public void testClientRetry(final String targetUrl,
+                                final String expectedExceptionString,
+                                final boolean shouldRetry)
+    throws Exception {
+        final int maxRetries = 2;
+        final AtomicInteger attemptedRetries = new AtomicInteger(0);
+
+        final PGPServerRetryHandler retryHandler = new PGPServerRetryHandler(maxRetries) {
+            @Override
+            protected void onRetry(final String retryReason, final int retryCount,
+                                   final HttpContext context) {
+                super.onRetry(retryReason, retryCount, context);
+
+                attemptedRetries.incrementAndGet();
+            }
+        };
+
+        // We use short timeouts for both timeouts since we don't want to hold up the tests on URLs
+        // we know will take a while.
+        final PGPKeysServerClient client
+            = new StubbedClient(new URI(targetUrl), SHORT_TEST_TIMEOUT, SHORT_TEST_TIMEOUT);
+
+        IOException caughtException = null;
+
+        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            client.copyKeyToOutputStream(TEST_KEYID, outputStream, retryHandler);
+        } catch (IOException ex) {
+            caughtException = ex;
+        }
+
+        assertNotNull(caughtException);
+        assertEquals(caughtException.toString(), expectedExceptionString);
+
+        if (shouldRetry) {
+            assertEquals(attemptedRetries.get(), maxRetries);
+        } else {
+            assertEquals(attemptedRetries.get(), 0);
+        }
+    }
+
+    /**
+     * A special key client that allows the URL the client is requesting to be stubbed-out by tests.
+     *
+     * <p>This is used by tests that are testing retry behavior, to allow them to control exactly
+     * which URL is being requested. Each URL provided by tests simulates a different type of
+     * failure.
+     */
+    private static class StubbedClient
+    extends PGPKeysServerClientHttps {
+        private final URI stubbedUri;
+
+        StubbedClient(final URI stubbedUri, final int connectTimeout, final int readTimeout)
+        throws CertificateException, NoSuchAlgorithmException, IOException, KeyManagementException,
+               KeyStoreException, URISyntaxException {
+            super(stubbedUri, connectTimeout, readTimeout);
+
+            this.stubbedUri = stubbedUri;
+        }
+
+        @Override
+        URI getUriForShowKey(long keyID) {
+            return this.stubbedUri;
+        }
+
+        @Override
+        URI getUriForGetKey(long keyID) {
+            return this.stubbedUri;
+        }
     }
 }

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -31,6 +31,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.http.protocol.HttpContext;
+import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -38,7 +39,6 @@ import org.testng.annotations.Test;
 public class PGPKeysServerClientIT {
     private static final long TEST_KEYID = 0xF8484389379ACEACL;
 
-    private static final int MAX_TEST_RETRIES = 10;
     private static final int SHORT_TEST_TIMEOUT = 1000;
 
     @DataProvider(name = "goodServerUrls")
@@ -100,7 +100,12 @@ public class PGPKeysServerClientIT {
 
         try (FileOutputStream outputStream = new FileOutputStream(tempFile)) {
             client.copyKeyToOutputStream(
-                TEST_KEYID, outputStream, new PGPServerRetryHandler(MAX_TEST_RETRIES));
+                TEST_KEYID,
+                outputStream,
+                new PGPServerRetryHandler(
+                    new SystemStreamLog(),
+                    PGPServerRetryHandler.DEFAULT_MAX_RETRIES,
+                    PGPServerRetryHandler.DEFAULT_BACKOFF_INTERVAL));
         }
 
         assertTrue(tempFile.length() > 0, "Downloaded key was not expected to be empty");

--- a/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
+++ b/src/test/java/org/simplify4u/plugins/PGPKeysServerClientIT.java
@@ -117,9 +117,7 @@ public class PGPKeysServerClientIT {
         final PGPServerRetryHandler retryHandler = new PGPServerRetryHandler(maxRetries) {
             @Override
             protected void onRetry(final String retryReason, final int retryCount,
-                                   final HttpContext context) {
-                super.onRetry(retryReason, retryCount, context);
-
+                                   final long backoffDelay, final HttpContext requestContext) {
                 attemptedRetries.incrementAndGet();
             }
         };


### PR DESCRIPTION
- Modifies the HTTP and HTTPS PGP clients to use the more-robust Apache HTTP Client instead of Java's built-in `URLConnection` classes, to support automatic retry on connection failures and generally to avoid failing as easily during PGP key requests. Now the client will recovery automatically on transient 5XX errors, connection timeouts, and read timeouts.
- Client will retry the same PGP server up to 10 times per type of failure (connection timeout vs. connection drop, etc).
- The default timeouts are:
  - 5 seconds to connect to the target server
  - 20 seconds to read the key from the server
- Uses a back-off strategy of +700 ms per retry attempt. So if the max retries were `3`, then:
  - First retry happens after 750 ms.
  - Second retry happens after 1,500 ms.
  - Third retry happens after 2,250 ms.

Timeouts are not yet user-configurable, but can be made configurable at a later time should the need arise.

Replaces #35. Closes #34.