### PR TITLE
Added configuration to skip execution

### DIFF
--- a/src/it/skipAll/pom.xml
+++ b/src/it/skipAll/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Slawomir Jaranowski
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.simplify4u.plugins</groupId>
+                <artifactId>pgpverify-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <failNoSignature>true</failNoSignature>
+                    <skip>true</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/skipAllByProp/pom.xml
+++ b/src/it/skipAllByProp/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Slawomir Jaranowski
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <pgpverify.skip>true</pgpverify.skip>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.simplify4u.plugins</groupId>
+                <artifactId>pgpverify-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <failNoSignature>true</failNoSignature>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -216,19 +216,31 @@ public class PGPVerifyMojo extends AbstractMojo {
     @Parameter(property = "pgpverify.keysMapLocation", defaultValue = "")
     private String keysMapLocation;
 
+    /**
+     * Skip verification altogether.
+     *
+     * @since 1.3.0
+     */
+    @Parameter(property = "pgpverify.skip", defaultValue = "false")
+    private boolean skip;
+
     private PGPKeysCache pgpKeysCache;
 
     private List<SkipFilter> skipFilters;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        prepareSkipFilters();
-        prepareForKeys();
+        if (skip) {
+            getLog().info("Skipping pgpverify:check");
+        } else {
+            prepareSkipFilters();
+            prepareForKeys();
 
-        try {
-            verifyArtifacts(getArtifactsToVerify());
-        } catch (ArtifactResolutionException | ArtifactNotFoundException e) {
-            throw new MojoExecutionException(e.getMessage(), e);
+            try {
+                verifyArtifacts(getArtifactsToVerify());
+            } catch (ArtifactResolutionException | ArtifactNotFoundException e) {
+                throw new MojoExecutionException(e.getMessage(), e);
+            }
         }
     }
 


### PR DESCRIPTION
Adding:

    <configuration>
        <skip>true</skip>
    </configuration>

or running `mvn` with `-Dpgpverify.skip=true` property skips execution altogether.

Fixes #37 