### PR TITLE
Add parameter 'strictNoSignature' to make missing signatures explicit in keys map

### DIFF
--- a/src/main/java/org/simplify4u/plugins/ArtifactInfo.java
+++ b/src/main/java/org/simplify4u/plugins/ArtifactInfo.java
@@ -76,4 +76,8 @@ public class ArtifactInfo {
     public boolean isKeyMatch(PGPPublicKey key) {
         return keyInfo.isKeyMatch(key);
     }
+
+    public boolean isNoKey() {
+        return keyInfo.isNoKey();
+    }
 }

--- a/src/main/java/org/simplify4u/plugins/KeyInfo.java
+++ b/src/main/java/org/simplify4u/plugins/KeyInfo.java
@@ -45,6 +45,10 @@ public class KeyInfo {
             throw new IllegalArgumentException("null key not allowed");
         }
 
+        if (strKeys.trim().isEmpty()) {
+            return;
+        }
+
         for (String key : strKeys.split(",")) {
             key = key.trim();
             if (key.startsWith("0x")) {
@@ -96,5 +100,9 @@ public class KeyInfo {
             }
         }
         return true;
+    }
+
+    public boolean isNoKey() {
+        return keysID.isEmpty();
     }
 }

--- a/src/main/java/org/simplify4u/plugins/KeysMap.java
+++ b/src/main/java/org/simplify4u/plugins/KeysMap.java
@@ -56,6 +56,15 @@ public class KeysMap {
         }
     }
 
+    public boolean isNoKey(Artifact artifact) {
+        for (ArtifactInfo artifactInfo : keysMapList) {
+            if (artifactInfo.isMatch(artifact)) {
+                return artifactInfo.isNoKey();
+            }
+        }
+        return false;
+    }
+
     public boolean isValidKey(Artifact artifact, PGPPublicKey key) {
         if (keysMapList.isEmpty()) {
             return true;
@@ -80,12 +89,12 @@ public class KeysMap {
             if (!currentLine.isEmpty() && !isCommentLine(currentLine)) {
                 final String[] parts = currentLine.split("=");
 
-                if (parts.length != 2) {
+                if (parts.length > 2) {
                     throw new IllegalArgumentException(
                         "Property line is malformed: " + currentLine);
                 }
 
-                keysMaps.put(parts[0], parts[1]);
+                keysMaps.put(parts[0], parts.length == 1 ? "" : parts[1]);
             }
         }
 

--- a/src/main/java/org/simplify4u/plugins/PGPSignatures.java
+++ b/src/main/java/org/simplify4u/plugins/PGPSignatures.java
@@ -30,6 +30,10 @@ import java.io.InputStream;
  */
 final class PGPSignatures {
 
+    private PGPSignatures() {
+        // No need to instantiate utility class.
+    }
+
     /**
      * Read the content of a file into the PGP signature instance (for verification).
      *

--- a/src/main/java/org/simplify4u/plugins/PGPSignatures.java
+++ b/src/main/java/org/simplify4u/plugins/PGPSignatures.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2017 Slawomir Jaranowski
+ * Portions Copyright 2017-2018 Wren Security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.simplify4u.plugins;
 
 import org.bouncycastle.openpgp.PGPSignature;

--- a/src/main/java/org/simplify4u/plugins/PGPSignatures.java
+++ b/src/main/java/org/simplify4u/plugins/PGPSignatures.java
@@ -1,0 +1,31 @@
+package org.simplify4u.plugins;
+
+import org.bouncycastle.openpgp.PGPSignature;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Utilities for PGP Signature class.
+ */
+final class PGPSignatures {
+
+    /**
+     * Read the content of a file into the PGP signature instance (for verification).
+     *
+     * @param signature the PGP signature instance. The instance is expected to be initialized.
+     * @param file      the file to read
+     * @throws IOException In case of failure to open the file or failure while reading its content.
+     */
+    static void readFileContentInto(final PGPSignature signature, final File file) throws IOException {
+        try (InputStream inArtifact = new BufferedInputStream(new FileInputStream(file))) {
+            int t;
+            while ((t = inArtifact.read()) >= 0) {
+                signature.update((byte) t);
+            }
+        }
+    }
+}

--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -488,8 +488,13 @@ public class PGPVerifyMojo extends AbstractMojo {
     private boolean verifyPGPSignature(Artifact artifact, Artifact ascArtifact)
     throws MojoFailureException {
         if (ascArtifact == null) {
-            final boolean noKeyConfirmed = keysMap.isNoKey(artifact);
-            if (noKeyConfirmed) {
+            if (keysMap.isNoKey(artifact)) {
+                final String logMessage = String.format("%s PGP Signature missing, consistent with keys map.", artifact.getId());
+                if (quiet) {
+                    getLog().debug(logMessage);
+                } else {
+                    getLog().info(logMessage);
+                }
                 return true;
             }
             getLog().error("Artifact without signature not listed in keys map: " + artifact.getId());

--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -133,7 +133,18 @@ public class PGPVerifyMojo extends AbstractMojo {
     private boolean failNoSignature;
 
     /**
-     * Fail the build if any artifact without key is not present in the keys list.
+     * Fail the build if any artifact without key is not present in the keys map.
+     * <p>
+     * When enabled, PGPVerify will look up all artifacts in the <code>keys
+     * map</code>. Unsigned artifacts will need to be present in the keys map
+     * but are expected to have no public key, i.e. an empty string.
+     * <p>
+     * When <code>strictNoSignature</code> is enabled, PGPVerify will no longer
+     * output warnings when unsigned artifacts are encountered. Instead, it will
+     * check if the unsigned artifact is listed in the <code>keys map</code>. If
+     * so it will proceed, if not it will fail the build.
+     *
+     * @since 1.5.0
      */
     @Parameter(property = "pgpverify.strictNoSignature", defaultValue = "false")
     private boolean strictNoSignature;
@@ -211,7 +222,10 @@ public class PGPVerifyMojo extends AbstractMojo {
      * wildcard.</p>
      *
      * <p><code>pgpKey</code> must be written as hex number starting with 0x.
-     * You can use <code>*</code> or <code>any</code> for match any pgp key.</p>
+     * You can use <code>*</code> or <code>any</code> for match any pgp key.
+     * If the pgpKey is an empty string, pgp-verify will expect the package to
+     * be unsigned. Please refer to <code>strictNoSignature</code> configuration
+     * parameter for its use.</p>
      *
      * <p>You can also omit <code>version</code> and <code>artifactId</code> which means any value
      * for those fields.</p>

--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -502,17 +502,7 @@ public class PGPVerifyMojo extends AbstractMojo {
     private boolean verifyPGPSignature(Artifact artifact, Artifact ascArtifact)
     throws MojoFailureException {
         if (ascArtifact == null) {
-            if (keysMap.isNoKey(artifact)) {
-                final String logMessage = String.format("%s PGP Signature unavailable, consistent with keys map.", artifact.getId());
-                if (quiet) {
-                    getLog().debug(logMessage);
-                } else {
-                    getLog().info(logMessage);
-                }
-                return true;
-            }
-            getLog().error("Artifact without signature not listed in keys map: " + artifact.getId());
-            return false;
+            return verifySignatureUnavailable(artifact);
         }
         final File artifactFile = artifact.getFile();
         final File signatureFile = ascArtifact.getFile();
@@ -587,6 +577,28 @@ public class PGPVerifyMojo extends AbstractMojo {
         } catch (IOException | PGPException e) {
             throw new MojoFailureException(e.getMessage(), e);
         }
+    }
+
+    /**
+     * Verify if unsigned artifact is correctly listed in keys map.
+     *
+     * @param artifact the artifact which is supposedly unsigned
+     * @return Returns <code>true</code> if correctly missing according to keys map,
+     * or <code>false</code> if verification fails.
+     */
+    private boolean verifySignatureUnavailable(final Artifact artifact) {
+        if (keysMap.isNoKey(artifact)) {
+            final String logMessage = String.format("%s PGP Signature unavailable, consistent with keys map.",
+                    artifact.getId());
+            if (quiet) {
+                getLog().debug(logMessage);
+            } else {
+                getLog().info(logMessage);
+            }
+            return true;
+        }
+        getLog().error("Unsigned artifact not listed in keys map: " + artifact.getId());
+        return false;
     }
 
     /**

--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -529,6 +529,17 @@ public class PGPVerifyMojo extends AbstractMojo {
             }
             PGPSignature pgpSignature = sigList.get(0);
 
+            if (weakSignatures.containsKey(pgpSignature.getHashAlgorithm())) {
+                final String logMessageWeakSignature = "Weak signature algorithm used: "
+                        + weakSignatures.get(pgpSignature.getHashAlgorithm());
+                if (failWeakSignature) {
+                    getLog().error(logMessageWeakSignature);
+                    throw new MojoFailureException(logMessageWeakSignature);
+                } else {
+                    getLog().warn(logMessageWeakSignature);
+                }
+            }
+
             PGPPublicKey publicKey = pgpKeysCache.getKey(pgpSignature.getKeyID());
 
             if (!keysMap.isValidKey(artifact, publicKey)) {
@@ -547,16 +558,6 @@ public class PGPVerifyMojo extends AbstractMojo {
                     getLog().debug(logMessageOK);
                 } else {
                     getLog().info(logMessageOK);
-                }
-                if (weakSignatures.containsKey(pgpSignature.getHashAlgorithm())) {
-                    final String logMessageWeakSignature = "Weak signature algorithm used: "
-                            + weakSignatures.get(pgpSignature.getHashAlgorithm());
-                    if (failWeakSignature) {
-                        getLog().error(logMessageWeakSignature);
-                        throw new MojoFailureException(logMessageWeakSignature);
-                    } else {
-                        getLog().warn(logMessageWeakSignature);
-                    }
                 }
                 return true;
             } else {

--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -489,7 +489,7 @@ public class PGPVerifyMojo extends AbstractMojo {
     throws MojoFailureException {
         if (ascArtifact == null) {
             if (keysMap.isNoKey(artifact)) {
-                final String logMessage = String.format("%s PGP Signature missing, consistent with keys map.", artifact.getId());
+                final String logMessage = String.format("%s PGP Signature unavailable, consistent with keys map.", artifact.getId());
                 if (quiet) {
                     getLog().debug(logMessage);
                 } else {

--- a/src/test/java/org/simplify4u/plugins/KeyInfoTest.java
+++ b/src/test/java/org/simplify4u/plugins/KeyInfoTest.java
@@ -39,7 +39,7 @@ public class KeyInfoTest {
                 {"0x123456789abcdef0,0x0fedcba987654321", 0x123456789abcdef0L, true},
                 {"0x123456789abcdef0, 0x0fedcba987654321", 0x123456789abcdef0L, true},
                 {"0x123456789abcdef0", 0x231456789abcdef0L, false},
-                {"0x123456789abcdef0, 0x0fedcba987654321", 0x321456789abcdef0L, false},
+                {"0x123456789abcdef0, 0x0fedcba987654321", 0x321456789abcdef0L, false}
         };
     }
 

--- a/src/test/java/org/simplify4u/plugins/KeyInfoTest.java
+++ b/src/test/java/org/simplify4u/plugins/KeyInfoTest.java
@@ -20,6 +20,8 @@ import org.testng.annotations.Test;
 
 import static org.simplify4u.plugins.TestUtils.getPGPgpPublicKey;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
 
 /**
  * @author Slawomir Jaranowski.
@@ -37,7 +39,7 @@ public class KeyInfoTest {
                 {"0x123456789abcdef0,0x0fedcba987654321", 0x123456789abcdef0L, true},
                 {"0x123456789abcdef0, 0x0fedcba987654321", 0x123456789abcdef0L, true},
                 {"0x123456789abcdef0", 0x231456789abcdef0L, false},
-                {"0x123456789abcdef0, 0x0fedcba987654321", 0x321456789abcdef0L, false}
+                {"0x123456789abcdef0, 0x0fedcba987654321", 0x321456789abcdef0L, false},
         };
     }
 
@@ -46,5 +48,19 @@ public class KeyInfoTest {
 
         KeyInfo keyInfo = new KeyInfo(strKeys);
         assertEquals(keyInfo.isKeyMatch(getPGPgpPublicKey(key)), match);
+    }
+
+    @Test
+    public void testIsNoKey() {
+
+        KeyInfo keyInfo = new KeyInfo("");
+        assertTrue(keyInfo.isNoKey());
+    }
+
+    @Test
+    public void testIsNoKeyIncorrect() {
+
+        KeyInfo keyInfo = new KeyInfo("0x123456789abcdef0");
+        assertFalse(keyInfo.isNoKey());
     }
 }

--- a/src/test/java/org/simplify4u/plugins/KeysMapTest.java
+++ b/src/test/java/org/simplify4u/plugins/KeysMapTest.java
@@ -106,4 +106,20 @@ public class KeysMapTest {
             getArtifact("test", "test-package", "1.0.0"),
             getPGPgpPublicKey(0xA6ADFC93EF34893EL)));
     }
+
+    @Test
+    public void artifactsWithoutKeysProcessed() throws Exception {
+        keysMap.load("/keysMap3.list");
+
+        assertTrue(
+          keysMap.isNoKey(
+            getArtifact("test", "test-package", "1.0.0")));
+        assertFalse(
+          keysMap.isValidKey(
+            getArtifact("test", "test-package", "1.0.0"),
+            getPGPgpPublicKey(0xA6ADFC93EF34893EL)));
+        assertFalse(
+          keysMap.isNoKey(
+            getArtifact("test", "test-package-2", "1.0.0")));
+    }
 }

--- a/src/test/resources/keysMap3.list
+++ b/src/test/resources/keysMap3.list
@@ -1,0 +1,17 @@
+#
+# Copyright 2015 Slawomir Jaranowski
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+test:test-package:*=
+test:test-package-2:*=0xA6ADFC93EF34893E


### PR DESCRIPTION
Added maven configuration parameter `strictNoSignature` to express missing signatures for individual artifacts akin to how public keys are specified, in the keys map.

The following use cases are covered:
- This provides support for issue #16:
- Ability to detect new artifacts that are missing signatures in set-up where there exist already some artifacts that are missing a signature. (Use case where `failNoSignature` is too strict.)
- Ability to make explicit for which artifacts we do not expect signatures.

Features:
- `quiet` parameter is respected.
- logs correct verification if artifact is missing signature consistent with keys map.
