### PR TITLE
Fix unreliable move of freshly downloaded public key file

### DIFF
--- a/src/main/java/org/simplify4u/plugins/PGPKeysCache.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysCache.java
@@ -120,19 +120,16 @@ public class PGPKeysCache {
 
         File partFile = File.createTempFile(String.valueOf(keyId), "pgp-public-key");
 
-        try (BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(partFile))) {
-            keysServerClient.copyKeyToOutputStream(keyId, outputStream, new PGPServerRetryHandler(this.log));
+        try {
+            try (BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(partFile))) {
+                keysServerClient.copyKeyToOutputStream(keyId, outputStream, new PGPServerRetryHandler(this.log));
+            }
+            Files.move(partFile.toPath(), keyFile.toPath());
         } catch (IOException e) {
             // if error try remove file
             deleteFile(keyFile);
             deleteFile(partFile);
             throw e;
-        }
-
-        if (!partFile.renameTo(keyFile) && !keyFile.exists()) {
-            deleteFile(keyFile);
-            deleteFile(partFile);
-            throw new IOException(String.format("Can't move file %s to %s", partFile, keyFile));
         }
 
         log.info(String.format("Receive key: %s%n\tto %s", keysServerClient.getUriForGetKey(keyId), keyFile));

--- a/src/main/java/org/simplify4u/plugins/PGPKeysCache.java
+++ b/src/main/java/org/simplify4u/plugins/PGPKeysCache.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -124,7 +125,7 @@ public class PGPKeysCache {
             try (BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(partFile))) {
                 keysServerClient.copyKeyToOutputStream(keyId, outputStream, new PGPServerRetryHandler(this.log));
             }
-            Files.move(partFile.toPath(), keyFile.toPath());
+            Files.move(partFile.toPath(), keyFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             // if error try remove file
             deleteFile(keyFile);


### PR DESCRIPTION
In Fedora Toolbox-environment, key retrieval would fail due to a failure to move the downloaded public key from the temporary location to the PGP keys cache. By using the utility [Files.move](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#move(java.nio.file.Path,%20java.nio.file.Path,%20java.nio.file.CopyOption...)) this action becomes more reliable and is guaranteed to be platform-independent.

The produced stack traces were not helpful in case of failure using the old move mechanism.
```java
java.io.IOException: Can't move file /tmp/-64362105801389810586520046351922325613pgp-public-key to /var/home/danny/dev/pgpverify-maven-plugin/target/it-repo/pgpkeys-cache/A6/AD/A6ADFC93EF34893E.asc
            at org.simplify4u.plugins.PGPKeysCache.receiveKey (PGPKeysCache.java:135)
            [...]
```