### PR TITLE
Clarify error message for failure to process artifact signature

### DIFF
--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -426,7 +426,8 @@ public class PGPVerifyMojo extends AbstractMojo {
             }
 
         } catch (IOException | PGPException e) {
-            throw new MojoFailureException(e.getMessage(), e);
+            throw new MojoFailureException("Failed to process signature '" + signatureFile + "' for artifact "
+                    + artifact.getId(), e);
         }
     }
 


### PR DESCRIPTION
Clarify the error message sufficiently such that the error message itself is sufficient to start investigating the problem.