### PR TITLE
Add all build plug-in dependencies to the artifacts list whenever build plugins are validated

### DIFF
--- a/src/it/sigOkKeysMapWithPlugins/keysmap.list
+++ b/src/it/sigOkKeysMapWithPlugins/keysmap.list
@@ -24,3 +24,7 @@ org.apache.maven.plugins:maven-install-plugin:2.4=0x873A8E86B4372146
 org.apache.maven.plugins:maven-deploy-plugin:2.7=0xC7CA19B7B620D787
 org.apache.maven.plugins:maven-site-plugin:3.3=0xC92C5FEC70161C62
 org.apache.maven.plugins:maven-clean-plugin:2.5=0x873A8E86B4372146
+org.apache.maven.plugins:maven-pmd-plugin:* = 0xC870735180244047DA600FDEC171A58398EEC284
+#
+# Plugin dependencies:
+net.sourceforge.pmd:*:* = 0x912E716EF6D98746F8EEB4D182DE7BE82166E84E

--- a/src/it/sigOkKeysMapWithPlugins/pom.xml
+++ b/src/it/sigOkKeysMapWithPlugins/pom.xml
@@ -76,6 +76,23 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.12.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>net.sourceforge.pmd</groupId>
+                        <artifactId>pmd-core</artifactId>
+                        <version>6.15.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>net.sourceforge.pmd</groupId>
+                        <artifactId>pmd-java</artifactId>
+                        <version>6.15.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/sigOkKeysMapWithPlugins/postbuild.groovy
+++ b/src/it/sigOkKeysMapWithPlugins/postbuild.groovy
@@ -32,5 +32,11 @@ assert buildLog.text.contains('[INFO] org.apache.maven.plugins:maven-site-plugin
 assert buildLog.text.contains('[INFO] org.apache.maven.plugins:maven-site-plugin:pom:3.3 PGP Signature OK')
 assert buildLog.text.contains('[INFO] org.apache.maven.plugins:maven-clean-plugin:maven-plugin:2.5 PGP Signature OK')
 assert buildLog.text.contains('[INFO] org.apache.maven.plugins:maven-clean-plugin:pom:2.5 PGP Signature OK')
+assert buildLog.text.contains('[INFO] org.apache.maven.plugins:maven-pmd-plugin:maven-plugin:3.12.0 PGP Signature OK')
+assert buildLog.text.contains('[INFO] org.apache.maven.plugins:maven-pmd-plugin:pom:3.12.0 PGP Signature OK')
+assert buildLog.text.contains('[INFO] net.sourceforge.pmd:pmd-java:jar:6.15.0 PGP Signature OK')
+assert buildLog.text.contains('[INFO] net.sourceforge.pmd:pmd-java:pom:6.15.0 PGP Signature OK')
+assert buildLog.text.contains('[INFO] net.sourceforge.pmd:pmd-core:jar:6.15.0 PGP Signature OK')
+assert buildLog.text.contains('[INFO] net.sourceforge.pmd:pmd-core:pom:6.15.0 PGP Signature OK')
 
 assert buildLog.text.contains('[INFO] BUILD SUCCESS')

--- a/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
+++ b/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
@@ -121,13 +121,17 @@ final class ArtifactResolver {
                 resolveArtifacts(project.getArtifacts(), filter, verifyPomFiles));
         if (verifyPlugins) {
             allArtifacts.addAll(resolveArtifacts(project.getPluginArtifacts(), filter, verifyPomFiles));
-            // NOTE only immediate plug-in dependencies are validated. Indirect dependenies are not validated yet.
+            // Maven does not allow specifying version ranges for build plug-in
+            // dependencies, therefore we can use the literal specified
+            // dependency.
+            // TODO: only immediate plug-in dependencies are validated. Indirect dependencies are not validated yet.
             allArtifacts.addAll(resolveArtifacts(
                     project.getBuildPlugins().stream()
                             .flatMap(p -> p.getDependencies().stream())
                             .map(repositorySystem::createDependencyArtifact)
                             .collect(Collectors.toList()),
                     filter, verifyPomFiles));
+            // TODO: there is a common special source of additional jars: maven-compiler-plugin's annotationProcessorPaths configuration section, which references jars to be loaded as annotation processors.
         }
         log.debug("Discovered project artifacts: " + allArtifacts);
         return allArtifacts;

--- a/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
+++ b/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
@@ -121,6 +121,7 @@ final class ArtifactResolver {
                 resolveArtifacts(project.getArtifacts(), filter, verifyPomFiles));
         if (verifyPlugins) {
             allArtifacts.addAll(resolveArtifacts(project.getPluginArtifacts(), filter, verifyPomFiles));
+            // NOTE only immediate plug-in dependencies are validated. Indirect dependenies are not validated yet.
             allArtifacts.addAll(resolveArtifacts(
                     project.getBuildPlugins().stream()
                             .flatMap(p -> p.getDependencies().stream())

--- a/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
+++ b/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
@@ -121,7 +121,12 @@ final class ArtifactResolver {
                 resolveArtifacts(project.getArtifacts(), filter, verifyPomFiles));
         if (verifyPlugins) {
             allArtifacts.addAll(resolveArtifacts(project.getPluginArtifacts(), filter, verifyPomFiles));
-            // NOTE: plug-in artifacts are included, but plug-in's dependencies aren't yet.
+            allArtifacts.addAll(resolveArtifacts(
+                    project.getBuildPlugins().stream()
+                            .flatMap(p -> p.getDependencies().stream())
+                            .map(repositorySystem::createDependencyArtifact)
+                            .collect(Collectors.toList()),
+                    filter, verifyPomFiles));
         }
         log.debug("Discovered project artifacts: " + allArtifacts);
         return allArtifacts;


### PR DESCRIPTION
Add dependencies of build plug-ins as well as the build plug-ins themselves to the artifact validation list. (#54)

Given an earlier discovery that maven does not accept _Version Range_ specification for build plug-in dependencies, it is trivial to add plug-in dependency artifacts: there is no need for version conflict resolution.

@slawekjaranowski let me know if you really want to add this under another _configuration switch_. Right now this would be included as soon as build plug-ins are included. (Personally, I would like to avoid it.)
