### PR TITLE
Remove excessive newline for error log entry.

### DIFF
--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -397,7 +397,7 @@ public class PGPVerifyMojo extends AbstractMojo {
             if (!keysMap.isValidKey(artifact, publicKey)) {
                 String msg = String.format("%s = %s", ArtifactUtils.key(artifact), PublicKeyUtils.fingerprint(publicKey));
                 String keyUrl = pgpKeysCache.getUrlForShowKey(publicKey.getKeyID());
-                getLog().error(String.format("Not allowed artifact %s and keyID:%n\t%s%n\t%s%n",
+                getLog().error(String.format("Not allowed artifact %s and keyID:%n\t%s%n\t%s",
                         artifact.getId(), msg, keyUrl));
                 return false;
             }


### PR DESCRIPTION
The original formatting would leave an empty line after each `error` log entry.
I would expect that is accidental, so this patch removes it.