### PR TITLE
Validate annotation processors in maven-compiler-plugin

### DIFF
--- a/src/it/sigOkKeysMapWithPlugins/keysmap.list
+++ b/src/it/sigOkKeysMapWithPlugins/keysmap.list
@@ -25,6 +25,9 @@ org.apache.maven.plugins:maven-deploy-plugin:2.7=0xC7CA19B7B620D787
 org.apache.maven.plugins:maven-site-plugin:3.3=0xC92C5FEC70161C62
 org.apache.maven.plugins:maven-clean-plugin:2.5=0x873A8E86B4372146
 org.apache.maven.plugins:maven-pmd-plugin:* = 0xC870735180244047DA600FDEC171A58398EEC284
+org.apache.maven.plugins:maven-compiler-plugin:* = 0xAE9E53FC28FF2AB1012273D0BF1518E0160788A2
 #
 # Plugin dependencies:
 net.sourceforge.pmd:*:* = 0x912E716EF6D98746F8EEB4D182DE7BE82166E84E
+com.uber.nullaway:*:* = 0xD4FB0B7B5E8C18C993A8A386EB9D04A9A679FE18
+com.google.errorprone:*:* = 0xE77417AC194160A3FABD04969A259C7EE636C5ED

--- a/src/it/sigOkKeysMapWithPlugins/pom.xml
+++ b/src/it/sigOkKeysMapWithPlugins/pom.xml
@@ -66,6 +66,7 @@
                     <strictNoSignature>true</strictNoSignature>
                     <keysMapLocation>${project.basedir}/keysmap.list</keysMapLocation>
                     <verifyPlugins>true</verifyPlugins>
+                    <verifyAtypical>true</verifyAtypical>
                     <verifySnapshots>true</verifySnapshots>
                 </configuration>
                 <executions>
@@ -75,6 +76,34 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.3.3</version>
+                        </path>
+                        <path>
+                            <groupId>com.uber.nullaway</groupId>
+                            <artifactId>nullaway</artifactId>
+                            <version>0.7.8</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/sigOkKeysMapWithPlugins/postbuild.groovy
+++ b/src/it/sigOkKeysMapWithPlugins/postbuild.groovy
@@ -38,5 +38,8 @@ assert buildLog.text.contains('[INFO] net.sourceforge.pmd:pmd-java:jar:6.15.0 PG
 assert buildLog.text.contains('[INFO] net.sourceforge.pmd:pmd-java:pom:6.15.0 PGP Signature OK')
 assert buildLog.text.contains('[INFO] net.sourceforge.pmd:pmd-core:jar:6.15.0 PGP Signature OK')
 assert buildLog.text.contains('[INFO] net.sourceforge.pmd:pmd-core:pom:6.15.0 PGP Signature OK')
-
+assert buildLog.text.contains('[INFO] com.google.errorprone:error_prone_core:jar:2.3.3 PGP Signature OK')
+assert buildLog.text.contains('[INFO] com.google.errorprone:error_prone_core:pom:2.3.3 PGP Signature OK')
+assert buildLog.text.contains('[INFO] com.uber.nullaway:nullaway:jar:0.7.8 PGP Signature OK')
+assert buildLog.text.contains('[INFO] com.uber.nullaway:nullaway:pom:0.7.8 PGP Signature OK')
 assert buildLog.text.contains('[INFO] BUILD SUCCESS')

--- a/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
+++ b/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
@@ -127,7 +127,8 @@ final class ArtifactResolver {
         final LinkedHashSet<Artifact> allArtifacts = new LinkedHashSet<>(
                 resolveArtifacts(project.getArtifacts(), filter, verifyPomFiles));
         if (verifyPlugins) {
-            // FIXME: applying dependency filters to build plug-ins may result in all build plug-ins being dropped because these are listed as 'runtime'-scoped.
+            // FIXME: applying dependency filters to build plug-ins may result in all build plug-ins being dropped,
+            //  because these are listed as 'runtime'-scoped.
             allArtifacts.addAll(resolveArtifacts(project.getPluginArtifacts(), filter, verifyPomFiles));
             // Maven does not allow specifying version ranges for build plug-in dependencies, therefore we can use the
             // literal specified dependency.
@@ -142,7 +143,8 @@ final class ArtifactResolver {
             // verify artifacts in atypical locations, such as references in configuration.
             allArtifacts.addAll(resolveArtifacts(searchCompilerAnnotationProcessors(project), filter, verifyPomFiles));
         }
-        // TODO: only immediate dependencies are validated for build plug-in dependencies and maven-compiler-plugin annotation processors). Indirect dependencies (transitive closure) are not resolved yet.
+        // TODO: only immediate dependencies are validated for build plug-in dependencies and maven-compiler-plugin
+        //  annotation processors). Indirect dependencies (transitive closure) are not resolved yet.
         log.debug("Discovered project artifacts: " + allArtifacts);
         return allArtifacts;
     }

--- a/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
+++ b/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
@@ -127,7 +127,7 @@ final class ArtifactResolver {
         final LinkedHashSet<Artifact> allArtifacts = new LinkedHashSet<>(
                 resolveArtifacts(project.getArtifacts(), filter, verifyPomFiles));
         if (verifyPlugins) {
-            // TODO: applying dependency filters to build plug-ins may result in all build plug-ins being dropped because these are listed as 'runtime'-scoped.
+            // FIXME: applying dependency filters to build plug-ins may result in all build plug-ins being dropped because these are listed as 'runtime'-scoped.
             allArtifacts.addAll(resolveArtifacts(project.getPluginArtifacts(), filter, verifyPomFiles));
             // Maven does not allow specifying version ranges for build plug-in dependencies, therefore we can use the
             // literal specified dependency.
@@ -139,15 +139,15 @@ final class ArtifactResolver {
                     filter, verifyPomFiles));
         }
         if (verifyAtypical) {
-            // verify artifacts in atypical (configuration) locations, i.e. not dependencies.
-            allArtifacts.addAll(resolveArtifacts(findCompilerAnnotationProcessors(project), filter, verifyPomFiles));
+            // verify artifacts in atypical locations, such as references in configuration.
+            allArtifacts.addAll(resolveArtifacts(searchCompilerAnnotationProcessors(project), filter, verifyPomFiles));
         }
         // TODO: only immediate dependencies are validated for build plug-in dependencies and maven-compiler-plugin annotation processors). Indirect dependencies (transitive closure) are not resolved yet.
         log.debug("Discovered project artifacts: " + allArtifacts);
         return allArtifacts;
     }
 
-    private Collection<Artifact> findCompilerAnnotationProcessors(MavenProject project) {
+    private Collection<Artifact> searchCompilerAnnotationProcessors(MavenProject project) {
         return project.getBuildPlugins().stream()
                 .filter(MavenCompilerUtils::checkCompilerPlugin)
                 .flatMap(p -> extractAnnotationProcessors(repositorySystem, p).stream())

--- a/src/main/java/org/simplify4u/plugins/MavenCompilerUtils.java
+++ b/src/main/java/org/simplify4u/plugins/MavenCompilerUtils.java
@@ -1,0 +1,71 @@
+package org.simplify4u.plugins;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.repository.RepositorySystem;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.stream;
+import static java.util.Collections.emptySet;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utilities specific for org.apache.maven.plugins:maven-compiler-plugin.
+ */
+final class MavenCompilerUtils {
+
+    private static final String GROUPID = "org.apache.maven.plugins";
+    private static final String ARTIFACTID = "maven-compiler-plugin";
+
+    private static final String PACKAGING = "jar";
+
+    private MavenCompilerUtils() {
+        // No need to instantiate utility class.
+    }
+
+    /**
+     * Check if provided plugin is org.apache.maven.plugins:maven-compiler-plugin.
+     *
+     * @param plugin any plugin instance
+     * @return Returns true iff plugin is maven-compiler-plugin.
+     */
+    static boolean checkCompilerPlugin(Plugin plugin) {
+        return GROUPID.equals(plugin.getGroupId()) && ARTIFACTID.equals(plugin.getArtifactId());
+    }
+
+    /**
+     * Extract annotation processors for maven-compiler-plugin configuration.
+     *
+     * @param system maven repository system
+     * @param plugin maven-compiler-plugin plugin
+     * @return Returns set of maven artifacts configured as annotation processors.
+     */
+    static Set<Artifact> extractAnnotationProcessors(RepositorySystem system, Plugin plugin) {
+        requireNonNull(system);
+        if (!checkCompilerPlugin(plugin)) {
+            throw new IllegalArgumentException("Plugin is not '" + GROUPID + ":" + ARTIFACTID + "'.");
+        }
+        final Object config = plugin.getConfiguration();
+        if (config == null) {
+            return emptySet();
+        }
+        if (config instanceof Xpp3Dom) {
+            return stream(((Xpp3Dom) config).getChildren("annotationProcessorPaths"))
+                    .flatMap(aggregate -> stream(aggregate.getChildren("path")))
+                    .map(processor -> system.createArtifact(
+                            processor.getChild("groupId").getValue(),
+                            processor.getChild("artifactId").getValue(),
+                            processor.getChild("version").getValue(),
+                            PACKAGING))
+                    .collect(Collectors.toSet());
+        }
+        // It is expected that this will never occur due to all Configuration instances of all plugins being provided as
+        // XML document. If this happens to occur on very old plugin versions, we can safely add the type support and
+        // simply return an empty set.
+        throw new UnsupportedOperationException("Please report that an unsupported type of configuration container was encountered: "
+                + config.getClass());
+    }
+}

--- a/src/main/java/org/simplify4u/plugins/MavenCompilerUtils.java
+++ b/src/main/java/org/simplify4u/plugins/MavenCompilerUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Danny van Heumen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.simplify4u.plugins;
 
 import org.apache.maven.artifact.Artifact;

--- a/src/main/java/org/simplify4u/plugins/MavenCompilerUtils.java
+++ b/src/main/java/org/simplify4u/plugins/MavenCompilerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Danny van Heumen
+ * Copyright 2019 Danny van Heumen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/simplify4u/plugins/MavenCompilerUtils.java
+++ b/src/main/java/org/simplify4u/plugins/MavenCompilerUtils.java
@@ -85,8 +85,8 @@ final class MavenCompilerUtils {
         // It is expected that this will never occur due to all Configuration instances of all plugins being provided as
         // XML document. If this happens to occur on very old plugin versions, we can safely add the type support and
         // simply return an empty set.
-        throw new UnsupportedOperationException("Please report that an unsupported type of configuration container was encountered: "
-                + config.getClass());
+        throw new UnsupportedOperationException("Please report that an unsupported type of configuration container" +
+                " was encountered: " + config.getClass());
     }
 
     /**

--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -176,6 +176,17 @@ public class PGPVerifyMojo extends AbstractMojo {
     private boolean verifyPlugins;
 
     /**
+     * Verify dependency artifact in atypical locations:
+     * <ul>
+     *     <li>annotation processors in org.apache.maven.plugins:maven-compiler-plugin configuration.</li>
+     * </ul>
+     *
+     * @since 1.6.0
+     */
+    @Parameter(property = "pgpverify.verifyAtypical", defaultValue = "false")
+    private boolean verifyAtypical;
+
+    /**
      * Verify "provided" dependencies, which the JDK or a container provide at runtime.
      *
      * @since 1.2.0
@@ -271,7 +282,7 @@ public class PGPVerifyMojo extends AbstractMojo {
             final ArtifactResolver resolver = new ArtifactResolver(getLog(),
                     repositorySystem, localRepository, remoteRepositories);
             final Set<Artifact> artifacts = resolver.resolveProjectArtifacts(
-                    this.project, filter, this.verifyPomFiles, this.verifyPlugins);
+                    this.project, filter, this.verifyPomFiles, this.verifyPlugins, this.verifyAtypical);
             final SignatureRequirement signaturePolicy = determineSignaturePolicy();
             final Map<Artifact, Artifact> artifactMap = resolver.resolveSignatures(artifacts, signaturePolicy);
             verifyArtifactSignatures(artifactMap);

--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -52,6 +52,7 @@ import org.bouncycastle.openpgp.PGPUtil;
 import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
 import org.bouncycastle.openpgp.operator.bc.BcPGPContentVerifierBuilderProvider;
 import org.codehaus.plexus.resource.loader.ResourceNotFoundException;
+import org.simplify4u.plugins.ArtifactResolver.Configuration;
 import org.simplify4u.plugins.ArtifactResolver.SignatureRequirement;
 import org.simplify4u.plugins.skipfilters.CompositeSkipper;
 import org.simplify4u.plugins.skipfilters.ProvidedDependencySkipper;
@@ -282,9 +283,9 @@ public class PGPVerifyMojo extends AbstractMojo {
 
             final ArtifactResolver resolver = new ArtifactResolver(getLog(),
                     repositorySystem, localRepository, remoteRepositories);
-            final Set<Artifact> artifacts = resolver.resolveProjectArtifacts(
-                    this.project, dependencyFilter, pluginFilter, this.verifyPomFiles, this.verifyPlugins,
-                    this.verifyAtypical);
+            final Configuration config = new Configuration(dependencyFilter, pluginFilter, this.verifyPomFiles,
+                    this.verifyPlugins, this.verifyAtypical);
+            final Set<Artifact> artifacts = resolver.resolveProjectArtifacts(this.project, config);
             final SignatureRequirement signaturePolicy = determineSignaturePolicy();
             final Map<Artifact, Artifact> artifactMap = resolver.resolveSignatures(artifacts, signaturePolicy);
             verifyArtifactSignatures(artifactMap);

--- a/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
+++ b/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
@@ -79,7 +79,7 @@ public class ArtifactResolverTest {
         final MavenProject project = mock(MavenProject.class);
 
         final Set<Artifact> resolved = resolver.resolveProjectArtifacts(project,
-                new CompositeSkipper(emptyList()), false, false, false);
+                new CompositeSkipper(emptyList()), new CompositeSkipper(emptyList()), false, false, false);
         assertEquals(emptySet(), resolved);
     }
 
@@ -99,7 +99,7 @@ public class ArtifactResolverTest {
         when(project.getArtifacts()).thenReturn(singleton(artifact));
 
         final Set<Artifact> resolved = resolver.resolveProjectArtifacts(project,
-                new CompositeSkipper(emptyList()), false, false, false);
+                new CompositeSkipper(emptyList()), new CompositeSkipper(emptyList()), false, false, false);
         assertEquals(1, resolved.size());
         assertTrue(resolved.iterator().next().isResolved());
     }
@@ -121,7 +121,7 @@ public class ArtifactResolverTest {
         when(project.getArtifacts()).thenReturn(singleton(artifact));
 
         final Set<Artifact> resolvedSet = resolver.resolveProjectArtifacts(project,
-                new CompositeSkipper(emptyList()), true, false, false);
+                new CompositeSkipper(emptyList()), new CompositeSkipper(emptyList()), true, false, false);
         verify(repositorySystem, times(1))
                 .createProjectArtifact(eq("g"), eq("a"), eq("1.0"));
         assertEquals(resolvedSet.size(), 2);

--- a/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
+++ b/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
@@ -27,6 +27,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.RepositorySystem;
 import org.mockito.stubbing.Answer;
+import org.simplify4u.plugins.ArtifactResolver.Configuration;
 import org.simplify4u.plugins.ArtifactResolver.SignatureRequirement;
 import org.simplify4u.plugins.skipfilters.CompositeSkipper;
 import org.testng.annotations.Test;
@@ -78,8 +79,9 @@ public class ArtifactResolverTest {
         final ArtifactResolver resolver = new ArtifactResolver(log, repositorySystem, mock(ArtifactRepository.class), emptyList());
         final MavenProject project = mock(MavenProject.class);
 
-        final Set<Artifact> resolved = resolver.resolveProjectArtifacts(project,
-                new CompositeSkipper(emptyList()), new CompositeSkipper(emptyList()), false, false, false);
+        final Configuration config = new Configuration(new CompositeSkipper(emptyList()),
+                new CompositeSkipper(emptyList()), false, false, false);
+        final Set<Artifact> resolved = resolver.resolveProjectArtifacts(project, config);
         assertEquals(emptySet(), resolved);
     }
 
@@ -98,8 +100,9 @@ public class ArtifactResolverTest {
         final DefaultArtifact artifact = new DefaultArtifact("g", "a", "1.0", "compile", "jar", "classifier", null);
         when(project.getArtifacts()).thenReturn(singleton(artifact));
 
-        final Set<Artifact> resolved = resolver.resolveProjectArtifacts(project,
-                new CompositeSkipper(emptyList()), new CompositeSkipper(emptyList()), false, false, false);
+        final Configuration config = new Configuration(new CompositeSkipper(emptyList()),
+                new CompositeSkipper(emptyList()), false, false, false);
+        final Set<Artifact> resolved = resolver.resolveProjectArtifacts(project, config);
         assertEquals(1, resolved.size());
         assertTrue(resolved.iterator().next().isResolved());
     }
@@ -120,8 +123,9 @@ public class ArtifactResolverTest {
         final DefaultArtifact artifact = new DefaultArtifact("g", "a", "1.0", "compile", "jar", "classifier", null);
         when(project.getArtifacts()).thenReturn(singleton(artifact));
 
-        final Set<Artifact> resolvedSet = resolver.resolveProjectArtifacts(project,
-                new CompositeSkipper(emptyList()), new CompositeSkipper(emptyList()), true, false, false);
+        final Configuration config = new Configuration(new CompositeSkipper(emptyList()),
+                new CompositeSkipper(emptyList()), true, false, false);
+        final Set<Artifact> resolvedSet = resolver.resolveProjectArtifacts(project, config);
         verify(repositorySystem, times(1))
                 .createProjectArtifact(eq("g"), eq("a"), eq("1.0"));
         assertEquals(resolvedSet.size(), 2);

--- a/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
+++ b/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
@@ -79,7 +79,7 @@ public class ArtifactResolverTest {
         final MavenProject project = mock(MavenProject.class);
 
         final Set<Artifact> resolved = resolver.resolveProjectArtifacts(project,
-                new CompositeSkipper(emptyList()), false, false);
+                new CompositeSkipper(emptyList()), false, false, false);
         assertEquals(emptySet(), resolved);
     }
 
@@ -99,7 +99,7 @@ public class ArtifactResolverTest {
         when(project.getArtifacts()).thenReturn(singleton(artifact));
 
         final Set<Artifact> resolved = resolver.resolveProjectArtifacts(project,
-                new CompositeSkipper(emptyList()), false, false);
+                new CompositeSkipper(emptyList()), false, false, false);
         assertEquals(1, resolved.size());
         assertTrue(resolved.iterator().next().isResolved());
     }
@@ -121,7 +121,7 @@ public class ArtifactResolverTest {
         when(project.getArtifacts()).thenReturn(singleton(artifact));
 
         final Set<Artifact> resolvedSet = resolver.resolveProjectArtifacts(project,
-                new CompositeSkipper(emptyList()), true, false);
+                new CompositeSkipper(emptyList()), true, false, false);
         verify(repositorySystem, times(1))
                 .createProjectArtifact(eq("g"), eq("a"), eq("1.0"));
         assertEquals(resolvedSet.size(), 2);

--- a/src/test/java/org/simplify4u/plugins/MavenCompilerUtilsTest.java
+++ b/src/test/java/org/simplify4u/plugins/MavenCompilerUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Danny van Heumen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.simplify4u.plugins;
 
 import org.apache.maven.artifact.Artifact;

--- a/src/test/java/org/simplify4u/plugins/MavenCompilerUtilsTest.java
+++ b/src/test/java/org/simplify4u/plugins/MavenCompilerUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Danny van Heumen
+ * Copyright 2019 Danny van Heumen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/simplify4u/plugins/MavenCompilerUtilsTest.java
+++ b/src/test/java/org/simplify4u/plugins/MavenCompilerUtilsTest.java
@@ -1,0 +1,129 @@
+package org.simplify4u.plugins;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.repository.RepositorySystem;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.simplify4u.plugins.MavenCompilerUtils.checkCompilerPlugin;
+import static org.simplify4u.plugins.MavenCompilerUtils.extractAnnotationProcessors;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+@SuppressWarnings({"ConstantConditions", "SameParameterValue"})
+public final class MavenCompilerUtilsTest {
+
+    @Test
+    public void testCheckCompilerPlugin() {
+        assertThrows(NullPointerException.class, () -> checkCompilerPlugin(null));
+        final Plugin compilerPlugin = mock(Plugin.class);
+        when(compilerPlugin.getGroupId()).thenReturn("org.apache.maven.plugins");
+        when(compilerPlugin.getArtifactId()).thenReturn("maven-compiler-plugin");
+        when(compilerPlugin.getVersion()).thenReturn("3.8.1");
+        assertTrue(checkCompilerPlugin(compilerPlugin));
+        final Plugin otherPlugin = mock(Plugin.class);
+        when(otherPlugin.getGroupId()).thenReturn("org.apache.maven.plugin");
+        when(otherPlugin.getArtifactId()).thenReturn("some-other-plugin");
+        when(otherPlugin.getVersion()).thenReturn("3.5.9");
+        assertFalse(checkCompilerPlugin(otherPlugin));
+    }
+
+    @Test
+    public void testExtractAnnotationProcessorsIllegalInputs() {
+        assertThrows(NullPointerException.class, () -> extractAnnotationProcessors(null, null));
+        final Plugin badPlugin = mock(Plugin.class);
+        when(badPlugin.getGroupId()).thenReturn("org.my-bad-plugin");
+        when(badPlugin.getArtifactId()).thenReturn("bad-plugin");
+        when(badPlugin.getVersion()).thenReturn("1.1.1");
+        assertThrows(NullPointerException.class, () -> extractAnnotationProcessors(null, badPlugin));
+        final RepositorySystem repository = mock(RepositorySystem.class);
+        assertThrows(NullPointerException.class, () -> extractAnnotationProcessors(repository, null));
+        assertThrows(IllegalArgumentException.class, () -> extractAnnotationProcessors(repository, badPlugin));
+    }
+
+    @Test
+    public void testExtractAnnotationProcessorsNoConfiguration() {
+        final RepositorySystem repository = mock(RepositorySystem.class);
+        final Plugin plugin = mock(Plugin.class);
+        when(plugin.getGroupId()).thenReturn("org.apache.maven.plugins");
+        when(plugin.getArtifactId()).thenReturn("maven-compiler-plugin");
+        when(plugin.getVersion()).thenReturn("3.8.1");
+        assertEquals(extractAnnotationProcessors(repository, plugin), emptySet());
+    }
+
+    @Test
+    public void testExtractAnnotationProcessorsUnsupportedConfigurationType() {
+        final RepositorySystem repository = mock(RepositorySystem.class);
+        final Plugin plugin = mock(Plugin.class);
+        when(plugin.getGroupId()).thenReturn("org.apache.maven.plugins");
+        when(plugin.getArtifactId()).thenReturn("maven-compiler-plugin");
+        when(plugin.getVersion()).thenReturn("3.8.1");
+        when(plugin.getConfiguration()).thenReturn("Massive configuration encoded in magic \"Hello World!\" string.");
+        assertThrows(UnsupportedOperationException.class, () -> extractAnnotationProcessors(repository, plugin));
+    }
+
+    @Test
+    public void testExtractAnnotationProcessors() {
+        final RepositorySystem repository = mock(RepositorySystem.class);
+        final Plugin plugin = mock(Plugin.class);
+        when(plugin.getGroupId()).thenReturn("org.apache.maven.plugins");
+        when(plugin.getArtifactId()).thenReturn("maven-compiler-plugin");
+        when(plugin.getVersion()).thenReturn("3.8.1");
+        when(plugin.getConfiguration()).thenReturn(createConfiguration());
+        when(repository.createArtifact(anyString(), anyString(), anyString(), anyString())).thenAnswer(invocation -> {
+            final Artifact artifact = mock(Artifact.class);
+            when(artifact.getGroupId()).thenReturn(invocation.getArgument(0));
+            when(artifact.getArtifactId()).thenReturn(invocation.getArgument(1));
+            when(artifact.getVersion()).thenReturn(invocation.getArgument(2));
+            return artifact;
+        });
+        final Set<Artifact> result = extractAnnotationProcessors(repository, plugin);
+        assertEquals(result.size(), 1);
+        final Artifact resultElement = result.iterator().next();
+        assertEquals(resultElement.getGroupId(), "myGroupId");
+        assertEquals(resultElement.getArtifactId(), "myArtifactId");
+        assertEquals(resultElement.getVersion(), "1.2.3");
+    }
+
+    private static Xpp3Dom createConfiguration() {
+        final Xpp3Dom config = new Xpp3Dom("configuration");
+        final Xpp3Dom annotationProcessorPaths = new Xpp3Dom("annotationProcessorPaths");
+        annotationProcessorPaths.addChild(createPath("myGroupId", "myArtifactId", "1.2.3"));
+        annotationProcessorPaths.addChild(createPath("", "myArtifactId", "1.2.3"));
+        annotationProcessorPaths.addChild(createPath("myGroupId", "", "1.2.3"));
+        annotationProcessorPaths.addChild(createPath(null, "myArtifactId", "1.2.3"));
+        annotationProcessorPaths.addChild(createPath("myGroupId", null, "1.2.3"));
+        annotationProcessorPaths.addChild(createPath("myGroupId", "myArtifactId", null));
+        config.addChild(annotationProcessorPaths);
+        return config;
+    }
+
+    private static Xpp3Dom createPath(String groupId, String artifactId, String version) {
+        final Xpp3Dom path = new Xpp3Dom("path");
+        if (groupId != null) {
+            final Xpp3Dom groupIdNode = new Xpp3Dom("groupId");
+            groupIdNode.setValue(groupId);
+            path.addChild(groupIdNode);
+        }
+        if (artifactId != null) {
+            final Xpp3Dom artifactIdNode = new Xpp3Dom("artifactId");
+            artifactIdNode.setValue(artifactId);
+            path.addChild(artifactIdNode);
+        }
+        if (version != null) {
+            final Xpp3Dom versionNode = new Xpp3Dom("version");
+            versionNode.setValue(version);
+            path.addChild(versionNode);
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
This PR adds support for validating the annotation processors that might be listed in the maven-compiler-plugin configuration. These annotation processors are basically dependencies, but referenced through the configuration, instead of dependency listing.

- adds configuration parameter `verifyAtypical`, which currently only checks `maven-compiler-plugin` configuration for annotation processors, but can in the future contain other "exotic" locations.
- Fixes issue with dependencies filter being used for build plug-ins: filtering by scope is dangerous for plugins as these are all `runtime` artifacts.
- Created `Configuration` container such that all behavioral properties of the `ArtifactResolver` are combined in a single parameter.
- includes unit tests and IT tests

NOTE: As with build plugins, we currently only validate the referenced artifacts themselves. Their dependencies are ignored. (Though once we solve resolution, we can apply it in both cases.)