### PR TITLE
Add reporting plugins to artifact validation list when 'verifyPlugins'

### DIFF
--- a/src/it/sigOkKeysMapWithPlugins/keysmap.list
+++ b/src/it/sigOkKeysMapWithPlugins/keysmap.list
@@ -29,6 +29,7 @@ org.apache.maven.plugins:maven-install-plugin:3.0.0-M1 = 0xAE9E53FC28FF2AB101227
 org.apache.maven.plugins:maven-jar-plugin:3.2.0 = 0xFA77DCFEF2EE6EB2DEBEDD2C012579464D01C06A
 org.apache.maven.plugins:maven-pmd-plugin:* = 0xC870735180244047DA600FDEC171A58398EEC284
 org.apache.maven.plugins:maven-site-plugin:3.8.2 = 0x6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688
+org.apache.maven.plugins:maven-project-info-reports-plugin:3.0.0 = 0x6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688
 #
 # Plugin dependencies:
 net.sourceforge.pmd:*:* = 0x912E716EF6D98746F8EEB4D182DE7BE82166E84E

--- a/src/it/sigOkKeysMapWithPlugins/pom.xml
+++ b/src/it/sigOkKeysMapWithPlugins/pom.xml
@@ -126,4 +126,29 @@
             </plugin>
         </plugins>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>3.0.0</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>ci-management</report>
+                            <report>dependencies</report>
+                            <report>issue-management</report>
+                            <report>licenses</report>
+                            <report>plugins</report>
+                            <report>team</report>
+                            <report>scm</report>
+                            <report>summary</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+
 </project>

--- a/src/it/sigOkKeysMapWithPlugins/postbuild.groovy
+++ b/src/it/sigOkKeysMapWithPlugins/postbuild.groovy
@@ -42,4 +42,6 @@ assert buildLog.text.contains('[INFO] com.google.errorprone:error_prone_core:jar
 assert buildLog.text.contains('[INFO] com.google.errorprone:error_prone_core:pom:2.3.3 PGP Signature OK')
 assert buildLog.text.contains('[INFO] com.uber.nullaway:nullaway:jar:0.7.8 PGP Signature OK')
 assert buildLog.text.contains('[INFO] com.uber.nullaway:nullaway:pom:0.7.8 PGP Signature OK')
+assert buildLog.text.contains('[INFO] org.apache.maven.plugins:maven-project-info-reports-plugin:maven-plugin:3.0.0 PGP Signature OK')
+assert buildLog.text.contains('[INFO] org.apache.maven.plugins:maven-project-info-reports-plugin:pom:3.0.0 PGP Signature OK')
 assert buildLog.text.contains('[INFO] BUILD SUCCESS')

--- a/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
+++ b/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
@@ -123,6 +123,8 @@ final class ArtifactResolver {
         if (config.verifyPlugins) {
             allArtifacts.addAll(resolveArtifacts(project.getPluginArtifacts(), config.pluginFilter,
                     config.verifyPomFiles));
+            allArtifacts.addAll(resolveArtifacts(project.getReportArtifacts(), config.pluginFilter,
+                    config.verifyPomFiles));
             // Maven does not allow specifying version ranges for build plug-in dependencies, therefore we can use the
             // literal specified dependency.
             allArtifacts.addAll(resolveArtifacts(


### PR DESCRIPTION
This allows us to include reporting plug-ins in the artifact validation process.

Note: unless you want to introduce (yet another) configuration flag, this will be included in the `verifyPlugins` configuration parameter.

The `getReportPlugins()` method is marked deprecated, but even `maven-dependency-plugin` still uses it. I have not found another way to include the reporting plug-ins, so it seems reasonable to use this method for now. No replacement is indicated.
