### PR TITLE
Emit warning for missing keysmap.

### DIFF
--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2017 Slawomir Jaranowski
  * Portions Copyright 2017-2018 Wren Security.
- * Portions Copyright 2019 Danny van Heumen
+ * Portions Copyright 2019-2020 Danny van Heumen.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -372,7 +372,7 @@ public class PGPVerifyMojo extends AbstractMojo {
         initCache();
 
         try {
-            keysMap.load(keysMapLocation);
+            keysMap.load(getLog(), keysMapLocation);
         } catch (ResourceNotFoundException | IOException e) {
             throw new MojoExecutionException("load keys map", e);
         }

--- a/src/main/java/org/simplify4u/plugins/keysmap/KeysMap.java
+++ b/src/main/java/org/simplify4u/plugins/keysmap/KeysMap.java
@@ -23,14 +23,16 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.base.Strings;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.logging.Log;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.resource.ResourceManager;
 import org.codehaus.plexus.resource.loader.ResourceNotFoundException;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Slawomir Jaranowski.
@@ -43,12 +45,17 @@ public class KeysMap {
 
     private final List<ArtifactInfo> keysMapList = new ArrayList<>();
 
-    public void load(String locale) throws ResourceNotFoundException, IOException {
-        if (!Strings.isNullOrEmpty(locale) && !Strings.isNullOrEmpty(locale.trim())) {
-
+    public void load(Log log, String locale) throws ResourceNotFoundException, IOException {
+        requireNonNull(log);
+        if (locale != null && !locale.trim().isEmpty()) {
             try (final InputStream inputStream = resourceManager.getResourceAsInputStream(locale)) {
                 loadKeysMap(inputStream);
             }
+        }
+        if (keysMapList.isEmpty()) {
+            log.warn("No keysmap specified in configuration or keysmap contains no entries. PGPVerify will only " +
+                    "check artifacts against their signature. File corruption will be detected. However, without a " +
+                    "keysmap as a reference for trust, valid signatures of any public key will be accepted.");
         }
     }
 


### PR DESCRIPTION
Emit a warning explaining the limitation of validation when a reference of trust is missing.

This should help to inform users of the limitations that exist when using this plugin if no source of trust is specified.

Please, feel free to suggest a better warning message. This message is a bit verbose.