### PR TITLE
KeysMap: Limit line splitting into 2 parts.

### DIFF
--- a/src/main/java/org/simplify4u/plugins/keysmap/KeysMap.java
+++ b/src/main/java/org/simplify4u/plugins/keysmap/KeysMap.java
@@ -118,16 +118,8 @@ public class KeysMap {
         BufferedReader mapReader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.US_ASCII));
         String currentLine;
 
-
         while ((currentLine = getNextLine(mapReader)) != null) {
-
-            String[] parts = currentLine.split("=");
-
-            if (parts.length > 2) {
-                throw new IllegalArgumentException(
-                        "Property line is malformed: " + currentLine);
-            }
-
+            String[] parts = currentLine.split("=", 2);
             ArtifactInfo artifactInfo = createArtifactInfo(parts[0], parts.length == 1 ? "" : parts[1]);
             keysMapList.add(artifactInfo);
         }


### PR DESCRIPTION
I don't like writing unit tests to satisfy coverage criteria, so I'll just simplify the control flow instead.