### PR TITLE
Show, fix and start failing on compiler warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,19 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:all,-options,-processing</arg>
+                    </compilerArgs>
+                    <showWarnings>true</showWarnings>
+                    <failOnWarning>true</failOnWarning>
+                    <failOnError>true</failOnError>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+            <plugin>
                 <!-- prepare items in local repo for tests-->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/src/main/java/org/simplify4u/plugins/keyserver/PGPKeyNotFound.java
+++ b/src/main/java/org/simplify4u/plugins/keyserver/PGPKeyNotFound.java
@@ -21,6 +21,7 @@ import java.io.IOException;
  * Inform about PGP key not found on server.
  */
 public class PGPKeyNotFound extends IOException {
+    private static final long serialVersionUID = 1L;
 
     public PGPKeyNotFound() {
         super();

--- a/src/main/java/org/simplify4u/plugins/utils/PublicKeyUtils.java
+++ b/src/main/java/org/simplify4u/plugins/utils/PublicKeyUtils.java
@@ -118,7 +118,7 @@ public final class PublicKeyUtils {
             return Optional.empty();
         }
 
-        Iterator signatures = publicKey.getSignaturesOfType(PGPSignature.SUBKEY_BINDING);
+        Iterator<?> signatures = publicKey.getSignaturesOfType(PGPSignature.SUBKEY_BINDING);
         if (signatures.hasNext()) {
             PGPSignature sig = (PGPSignature) signatures.next();
             return Optional.ofNullable(publicKeyRing.getPublicKey(sig.getKeyID()));
@@ -190,7 +190,8 @@ public final class PublicKeyUtils {
 
         AtomicBoolean hasValidSignature = new AtomicBoolean(false);
 
-        subKey.getSignaturesOfType(signatureTypeToCheck).forEachRemaining(s -> Try.run(() -> {
+        Iterator<?> it = subKey.getSignaturesOfType(signatureTypeToCheck);
+        it.forEachRemaining(s -> Try.run(() -> {
                     PGPSignature sig = (PGPSignature) s;
 
                     PGPPublicKey masterKey = publicKeyRing.getPublicKey(sig.getKeyID());


### PR DESCRIPTION
(Not for release 1.8.0.)
Start showing compiler warnings and fail on these warnings. In my experience any compiler warning is a valid concern to be fixed so why not report them during maven builds and fail on these warnings.
