### PR TITLE
Report duration of artifact resolution, download and signature validation phases.

### DIFF
--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -309,18 +309,45 @@ public class PGPVerifyMojo extends AbstractMojo {
             final SkipFilter pluginFilter = preparePluginFilters();
             prepareForKeys();
 
+            final long artifactResolutionStart = System.nanoTime();
             final ArtifactResolver resolver = new ArtifactResolver(getLog(), repositorySystem, localRepository,
                     remoteRepositories);
             final Configuration config = new Configuration(dependencyFilter, pluginFilter, this.verifyPomFiles,
                     this.verifyPlugins, this.verifyPluginDependencies, this.verifyAtypical);
             final Set<Artifact> artifacts = resolver.resolveProjectArtifacts(this.project, config);
+            if (quiet) {
+                getLog().debug("Finished artifact resolution in " + (System.nanoTime() - artifactResolutionStart)
+                        + " nanoseconds.");
+            } else {
+                getLog().info("Finished artifact resolution in " + (System.nanoTime() - artifactResolutionStart)
+                        + " nanoseconds.");
+            }
+
             getLog().info("Validating " + artifacts.size() + " artifacts ...");
             if (getLog().isDebugEnabled()) {
                 getLog().debug("Discovered project artifacts: " + artifacts);
             }
+
+            final long signatureResolutionStart = System.nanoTime();
             final SignatureRequirement signaturePolicy = determineSignaturePolicy();
             final Map<Artifact, Artifact> artifactMap = resolver.resolveSignatures(artifacts, signaturePolicy);
+            if (quiet) {
+                getLog().debug("Finished signature resolution in " + (System.nanoTime()
+                        - signatureResolutionStart) + " nanoseconds.");
+            } else {
+                getLog().info("Finished signature resolution in " + (System.nanoTime()
+                        - signatureResolutionStart) + " nanoseconds.");
+            }
+
+            final long artifactValidationStart = System.nanoTime();
             verifyArtifactSignatures(artifactMap);
+            if (quiet) {
+                getLog().debug("Finished artifact validation in " + (System.nanoTime() - artifactValidationStart)
+                        + " nanoseconds.");
+            } else {
+                getLog().info("Finished artifact validation in " + (System.nanoTime() - artifactValidationStart)
+                        + " nanoseconds.");
+            }
         }
     }
 


### PR DESCRIPTION
In case you're interested in recording the durations(!?) I found it useful when performing full validation as it can take over 20 seconds even for small projects, so clearly noticeable. Feel free to decline if you're not interested, of course :-)

I use `System.nanoTime()` in the code as this is the only method that guarantees monotonically increasing timestaps such that durations can be measured accurately. (The nanosecond reporting - and possibly precision - is less significant here.)