### PR TITLE
Checksumming

### DIFF
--- a/src/main/java/org/simplify4u/plugins/ValidationChecksum.java
+++ b/src/main/java/org/simplify4u/plugins/ValidationChecksum.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020 Danny van Heumen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.simplify4u.plugins;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.artifact.Artifact;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.pqc.math.linearalgebra.ByteUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * ValidationChecksum is a checksum of a deterministic collection of artifacts.
+ *
+ * The checksum can be used to check against a stored value of a prior validation and for
+ * itself to be stored once full validation has completed.
+ */
+final class ValidationChecksum {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ValidationChecksum.class);
+
+    private final File file;
+    private final byte[] checksum;
+
+    private ValidationChecksum(File file, byte[] checksum) {
+        this.file = requireNonNull(file);
+        this.checksum = requireNonNull(checksum);
+    }
+
+    /**
+     * Compare current checksum against previously stored checksum value.
+     *
+     * @return Returns true iff checksum for previous run exists and is equal.
+     */
+    boolean checkValidation() {
+        if (disabled()) {
+            return false;
+        }
+        final byte[] checksumPriorValidation;
+        try {
+            LOG.debug("Looking for prior validation checksum at: {}", file.getAbsolutePath());
+            checksumPriorValidation = FileUtils.readFileToByteArray(file);
+        } catch (final FileNotFoundException e) {
+            LOG.debug("No prior validation executed. Continuing with full artifact validation.");
+            return false;
+        } catch (final IOException e) {
+            LOG.debug("Validation of artifacts against prior validation run failed.", e);
+            return false;
+        }
+
+        return Arrays.equals(this.checksum, checksumPriorValidation);
+    }
+
+    /**
+     * Save current checksum to file.
+     */
+    void saveChecksum() {
+        if (disabled()) {
+            return;
+        }
+        try {
+            FileUtils.writeByteArrayToFile(file, checksum);
+        } catch (final IOException e) {
+            LOG.debug("Failed to save checksum after successful artifact validation.", e);
+        }
+    }
+
+    boolean disabled() {
+        return this.checksum.length == 0;
+    }
+
+    /**
+     * A builder for the ValidationChecksum.
+     */
+    static final class Builder {
+
+        private static final String FILENAME_CHECKSUM_PRIOR_VALIDATION = "pgpverify-prior-validation-checksum";
+
+        private static final Logger LOG = LoggerFactory.getLogger(Builder.class);
+
+        private File file;
+
+        private boolean disabled;
+
+        private Iterable<Artifact> artifacts;
+
+        Builder() {
+        }
+
+        /**
+         * Destination for checksum file.
+         *
+         * @param directory the target directory
+         */
+        Builder destination(File directory) {
+            this.file = new File(directory, FILENAME_CHECKSUM_PRIOR_VALIDATION);
+            return this;
+        }
+
+        /**
+         * Set whether checksum calculation is disabled.
+         *
+         * @param disabled true if checksum is disabled, false otherwise.
+         */
+        Builder disabled(boolean disabled) {
+            this.disabled = disabled;
+            return this;
+        }
+
+        /**
+         * Perform checksum calculation on artifacts.
+         *
+         * @param artifacts the artifacts as deterministically ordered collection
+         */
+        Builder artifacts(Iterable<Artifact> artifacts) {
+            this.artifacts = requireNonNull(artifacts);
+            return this;
+        }
+
+        /**
+         * Build ValidationChecksum instance.
+         *
+         * @return Returns the validation checksum instance.
+         */
+        ValidationChecksum build() {
+            if (this.artifacts == null) {
+                throw new IllegalStateException("artifacts need to be provided");
+            }
+            return new ValidationChecksum(this.file, this.disabled ? new byte[0] : calculateChecksum());
+        }
+
+        private byte[] calculateChecksum() {
+            final SHA256Digest digest = new SHA256Digest();
+            final byte[] result = new byte[digest.getDigestSize()];
+            for (final Artifact artifact : this.artifacts) {
+                final byte[] id = artifact.getId().getBytes(UTF_8);
+                digest.update(id, 0, id.length);
+                digest.update((byte) '\0');
+            }
+            digest.doFinal(result, 0);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Checksum of resolved artifacts: {}", ByteUtils.toHexString(result, "0x", ""));
+            }
+            return result;
+        }
+
+        /**
+         * Delete a checksum if present in the specified directory.
+         *
+         * @param directory the target directory for a checksum file.
+         */
+        static void deleteChecksum(File directory) {
+            FileUtils.deleteQuietly(new File(directory, FILENAME_CHECKSUM_PRIOR_VALIDATION));
+        }
+    }
+}

--- a/src/test/java/org/simplify4u/plugins/ValidationChecksumTest.java
+++ b/src/test/java/org/simplify4u/plugins/ValidationChecksumTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Danny van Heumen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.simplify4u.plugins;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.File;
+
+import com.google.common.io.Files;
+
+import org.apache.maven.artifact.Artifact;
+import org.simplify4u.plugins.ValidationChecksum.Builder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ValidationChecksumTest {
+
+    private File checksumdirectory = null;
+
+    @BeforeMethod
+    public void setUp() {
+        this.checksumdirectory = Files.createTempDir();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        ValidationChecksum.Builder.deleteChecksum(checksumdirectory);
+        this.checksumdirectory.delete();
+    }
+
+    @Test
+    public void testValidationChecksumBuilderNullFile() {
+        new ValidationChecksum.Builder().destination(null).artifacts(emptyList()).build();
+    }
+
+    @Test
+    public void testValidationChecksumBuilderArtifactsNull() {
+        final Builder builder = new ValidationChecksum.Builder().destination(checksumdirectory);
+        assertThatCode(() -> builder.artifacts(null).build())
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testValidationChecksumBuilderArtifactsNotProvided() {
+        final Builder builder = new ValidationChecksum.Builder().destination(checksumdirectory);
+        assertThatCode(builder::build).isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testValidationChecksumBuilderChecksumEmptyCollection() {
+        final Builder builder = new ValidationChecksum.Builder().destination(checksumdirectory);
+        final ValidationChecksum checksum = builder.artifacts(emptyList()).build();
+        assertThat(checksum).isNotNull();
+        assertThat(checksum.checkValidation()).isFalse();
+    }
+
+    @Test
+    public void testValidationChecksumBuilderChecksumArtifactsNullFails() {
+        final Builder builder = new ValidationChecksum.Builder().destination(checksumdirectory);
+        final Artifact a1 = TestArtifactBuilder.testArtifact().groupId("org.apache.maven.plugins")
+                .artifactId("maven-compiler-plugin").packaging("jar").version("1.0").build();
+        final Artifact a2 = TestArtifactBuilder.testArtifact().groupId("org.apache.commons").artifactId("commons-io")
+                .packaging("jar").version("1.0").build();
+        assertThatCode(() -> builder.artifacts(asList(a1, a2, null)).build())
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testValidationChecksumBuilderChecksumArtifactsRepeatedly() {
+        final Builder builder = new ValidationChecksum.Builder().destination(checksumdirectory);
+        final Artifact a1 = TestArtifactBuilder.testArtifact()
+                .groupId("org.apache.maven.plugins").artifactId("maven-compiler-plugin")
+                .packaging("jar").version("1.0").build();
+        final Artifact a2 = TestArtifactBuilder.testArtifact()
+                .groupId("org.apache.commons").artifactId("commons-io")
+                .packaging("jar").version("1.0").build();
+        final Artifact a3 = TestArtifactBuilder.testArtifact()
+                .groupId("org.apache.commons").artifactId("commons-text")
+                .packaging("jar").version("1.1.1-3").build();
+        final ValidationChecksum checksum = builder.artifacts(asList(a1, a2, a3)).build();
+        assertThat(checksum).isNotNull();
+        assertThat(checksum.checkValidation()).isFalse();
+        checksum.saveChecksum();
+        assertThat(checksum.checkValidation()).isTrue();
+        assertThat(checksum.checkValidation()).isTrue();
+        assertThat(checksum.checkValidation()).isTrue();
+    }
+
+    @Test
+    public void testValidationChecksumBuilderChecksumArtifactsDeterministicOrder() {
+        final Builder builder = new ValidationChecksum.Builder().destination(checksumdirectory);
+        final Artifact a1 = TestArtifactBuilder.testArtifact()
+                .groupId("org.apache.maven.plugins").artifactId("maven-compiler-plugin")
+                .packaging("jar").version("1.0").build();
+        final Artifact a2 = TestArtifactBuilder.testArtifact()
+                .groupId("org.apache.commons").artifactId("commons-io")
+                .packaging("jar").version("1.0").build();
+        final Artifact a3 = TestArtifactBuilder.testArtifact()
+                .groupId("org.apache.commons").artifactId("commons-text")
+                .packaging("jar").version("1.1.1-3").build();
+        builder.artifacts(asList(a1, a2, a3)).build().saveChecksum();
+        assertThat(builder.artifacts(asList(a1, a3, a2)).build().checkValidation()).isFalse();
+        assertThat(builder.artifacts(asList(a2, a1, a3)).build().checkValidation()).isFalse();
+        assertThat(builder.artifacts(asList(a2, a3, a1)).build().checkValidation()).isFalse();
+        assertThat(builder.artifacts(asList(a3, a2, a1)).build().checkValidation()).isFalse();
+        assertThat(builder.artifacts(asList(a3, a1, a2)).build().checkValidation()).isFalse();
+        assertThat(builder.artifacts(asList(a1, a2, a3)).build().checkValidation()).isTrue();
+    }
+
+    @Test
+    public void testValidationChecksumBuilderChecksumArtifactsDisabled() {
+        final Builder builder = new ValidationChecksum.Builder().destination(checksumdirectory);
+        final Artifact a1 = TestArtifactBuilder.testArtifact()
+                .groupId("org.apache.maven.plugins").artifactId("maven-compiler-plugin")
+                .packaging("jar").version("1.0").build();
+        final Artifact a2 = TestArtifactBuilder.testArtifact()
+                .groupId("org.apache.commons").artifactId("commons-io")
+                .packaging("jar").version("1.0").build();
+        final Artifact a3 = TestArtifactBuilder.testArtifact()
+                .groupId("org.apache.commons").artifactId("commons-text")
+                .packaging("jar").version("1.1.1-3").build();
+        final ValidationChecksum checksum = builder.artifacts(asList(a1, a2, a3)).disabled(true).build();
+        assertThat(checksum).isNotNull();
+        assertThat(checksum.disabled()).isTrue();
+        assertThat(checksum.checkValidation()).isFalse();
+        checksum.saveChecksum();
+    }
+}


### PR DESCRIPTION
Compare artifacts-list against a checksum created in a prior validation. Effectively, only the first step - compiling the complete artifacts list - needs to be performed in all cases.

A checksum is calculating upon completing a full validation. The checksum is stored in the `target` directory, which contains maven build results. If a validation checksum is present in this directory, the artifacts-list checksum is compared against the stored checksum and if they match, pgpverify exits early with success result, instead of redundantly performing same validation steps.