### PR TITLE
Misc small improvements and simplifications

### DIFF
--- a/src/main/java/org/simplify4u/plugins/keysmap/KeysMap.java
+++ b/src/main/java/org/simplify4u/plugins/keysmap/KeysMap.java
@@ -22,18 +22,16 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.plugin.logging.Log;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.resource.ResourceManager;
 import org.codehaus.plexus.resource.loader.ResourceNotFoundException;
-
-import static java.util.Objects.requireNonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Slawomir Jaranowski.
@@ -41,20 +39,21 @@ import static java.util.Objects.requireNonNull;
 @Component(role = KeysMap.class, instantiationStrategy = "per-lookup")
 public class KeysMap {
 
+    private static final Logger LOG = LoggerFactory.getLogger(KeysMap.class);
+
     @Requirement
     private ResourceManager resourceManager;
 
-    private final List<ArtifactInfo> keysMapList = new ArrayList<>();
+    private final ArrayList<ArtifactInfo> keysMapList = new ArrayList<>();
 
-    public void load(Log log, String locale) throws ResourceNotFoundException, IOException {
-        requireNonNull(log);
+    public void load(String locale) throws ResourceNotFoundException, IOException {
         if (locale != null && !locale.trim().isEmpty()) {
             try (final InputStream inputStream = resourceManager.getResourceAsInputStream(locale)) {
                 loadKeysMap(inputStream);
             }
         }
         if (keysMapList.isEmpty()) {
-            log.warn("No keysmap specified in configuration or keysmap contains no entries. PGPVerify will only " +
+            LOG.warn("No keysmap specified in configuration or keysmap contains no entries. PGPVerify will only " +
                     "check artifacts against their signature. File corruption will be detected. However, without a " +
                     "keysmap as a reference for trust, valid signatures of any public key will be accepted.");
         }

--- a/src/main/java/org/simplify4u/plugins/utils/PGPSignatureUtils.java
+++ b/src/main/java/org/simplify4u/plugins/utils/PGPSignatureUtils.java
@@ -85,6 +85,7 @@ public final class PGPSignatureUtils {
      * @param input the input stream having PGPSignature content
      * @return Returns the (first) read PGP signature.
      * @throws IOException In case of bad content.
+     * @throws PGPSignatureException In case of failure loading signature.
      */
     public static PGPSignature loadSignature(InputStream input) throws IOException, PGPSignatureException {
 

--- a/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
+++ b/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
@@ -58,24 +58,20 @@ public class ArtifactResolverTest {
 
     @Test
     public void testConstructArtifactResolverWithNull() {
-        final Log log = mock(Log.class);
         final RepositorySystem repositorySystem = mock(RepositorySystem.class);
         final ArtifactRepository localRepository = mock(ArtifactRepository.class);
         assertThrows(NullPointerException.class,
-                () -> new ArtifactResolver(null, null, null, null));
+                () -> new ArtifactResolver(null, null, null));
         assertThrows(NullPointerException.class,
-                () -> new ArtifactResolver(null, repositorySystem, localRepository, emptyList()));
+                () -> new ArtifactResolver(null, localRepository, emptyList()));
         assertThrows(NullPointerException.class,
-                () -> new ArtifactResolver(log, null, localRepository, emptyList()));
+                () -> new ArtifactResolver(repositorySystem, null, emptyList()));
         assertThrows(NullPointerException.class,
-                () -> new ArtifactResolver(log, repositorySystem, null, emptyList()));
-        assertThrows(NullPointerException.class,
-                () -> new ArtifactResolver(log, repositorySystem, localRepository, null));
+                () -> new ArtifactResolver(repositorySystem, localRepository, null));
     }
 
     @Test
     public void testResolveProjectArtifactsEmpty() throws MojoExecutionException {
-        final Log log = mock(Log.class);
         final RepositorySystem repositorySystem = mock(RepositorySystem.class);
         final MavenSession session = mock(MavenSession.class);
         final ProjectBuildingRequest projectBuildingRequest = mock(ProjectBuildingRequest.class);
@@ -85,7 +81,7 @@ public class ArtifactResolverTest {
         final List<ArtifactRepository> remoteRepositories = emptyList();
         when(projectBuildingRequest.getRemoteRepositories()).thenReturn(remoteRepositories);
 
-        final ArtifactResolver resolver = new ArtifactResolver(log, repositorySystem, localRepository, remoteRepositories);
+        final ArtifactResolver resolver = new ArtifactResolver(repositorySystem, localRepository, remoteRepositories);
         final MavenProject project = mock(MavenProject.class);
 
         final Configuration config = new Configuration(new CompositeSkipper(emptyList()),
@@ -96,7 +92,6 @@ public class ArtifactResolverTest {
 
     @Test
     public void testResolveProjectArtifactsWithoutPoms() throws MojoExecutionException {
-        final Log log = mock(Log.class);
         final RepositorySystem repositorySystem = mock(RepositorySystem.class);
         final MavenSession session = mock(MavenSession.class);
         final ProjectBuildingRequest projectBuildingRequest = mock(ProjectBuildingRequest.class);
@@ -111,7 +106,7 @@ public class ArtifactResolverTest {
             artifact.setResolved(true);
             return new ArtifactResolutionResult();
         });
-        final ArtifactResolver resolver = new ArtifactResolver(log, repositorySystem, localRepository, remoteRepositories);
+        final ArtifactResolver resolver = new ArtifactResolver(repositorySystem, localRepository, remoteRepositories);
         final MavenProject project = mock(MavenProject.class);
         final DefaultArtifact artifact = new DefaultArtifact("g", "a", "1.0", "compile", "jar", "classifier", null);
         when(project.getArtifacts()).thenReturn(singleton(artifact));
@@ -125,7 +120,6 @@ public class ArtifactResolverTest {
 
     @Test
     public void testResolveProjectArtifactsWithPoms() throws MojoExecutionException {
-        final Log log = mock(Log.class);
         final RepositorySystem repositorySystem = mock(RepositorySystem.class);
         final MavenSession session = mock(MavenSession.class);
         final ProjectBuildingRequest projectBuildingRequest = mock(ProjectBuildingRequest.class);
@@ -141,7 +135,7 @@ public class ArtifactResolverTest {
         });
         when(repositorySystem.createProjectArtifact(eq("g"), eq("a"), eq("1.0")))
                 .thenReturn(new DefaultArtifact("g", "a", "1.0", "compile", "pom", "classifier", null));
-        final ArtifactResolver resolver = new ArtifactResolver(log, repositorySystem, localRepository, remoteRepositories);
+        final ArtifactResolver resolver = new ArtifactResolver(repositorySystem, localRepository, remoteRepositories);
         final MavenProject project = mock(MavenProject.class);
         final DefaultArtifact artifact = new DefaultArtifact("g", "a", "1.0", "compile", "jar", "classifier", null);
         when(project.getArtifacts()).thenReturn(singleton(artifact));
@@ -161,7 +155,6 @@ public class ArtifactResolverTest {
 
     @Test
     public void testResolveSignaturesEmpty() throws MojoExecutionException {
-        final Log log = mock(Log.class);
         final RepositorySystem repositorySystem = mock(RepositorySystem.class);
         final MavenSession session = mock(MavenSession.class);
         final ProjectBuildingRequest projectBuildingRequest = mock(ProjectBuildingRequest.class);
@@ -170,7 +163,7 @@ public class ArtifactResolverTest {
         when(projectBuildingRequest.getLocalRepository()).thenReturn(localRepository);
         final List<ArtifactRepository> remoteRepositories = emptyList();
         when(projectBuildingRequest.getRemoteRepositories()).thenReturn(remoteRepositories);
-        final ArtifactResolver resolver = new ArtifactResolver(log, repositorySystem, localRepository, remoteRepositories);
+        final ArtifactResolver resolver = new ArtifactResolver(repositorySystem, localRepository, remoteRepositories);
         final Map<Artifact, Artifact> resolvedSignatures = resolver.resolveSignatures(
                 emptyList(), SignatureRequirement.NONE);
         assertEquals(resolvedSignatures.size(), 0);
@@ -178,7 +171,6 @@ public class ArtifactResolverTest {
 
     @Test
     public void testResolveSignaturesResolved() throws MojoExecutionException {
-        final Log log = mock(Log.class);
         final RepositorySystem repositorySystem = mock(RepositorySystem.class);
         final MavenSession session = mock(MavenSession.class);
         final ProjectBuildingRequest projectBuildingRequest = mock(ProjectBuildingRequest.class);
@@ -194,7 +186,7 @@ public class ArtifactResolverTest {
         });
         when(repositorySystem.createArtifactWithClassifier(eq("g"), eq("a"), eq("1.0"), eq("jar"), isNull()))
                 .thenReturn(new DefaultArtifact("g", "a", "1.0", "compile", "mock-signature-artifact", null, new DefaultArtifactHandler()));
-        final ArtifactResolver resolver = new ArtifactResolver(log, repositorySystem, localRepository, remoteRepositories);
+        final ArtifactResolver resolver = new ArtifactResolver(repositorySystem, localRepository, remoteRepositories);
         final MavenProject project = mock(MavenProject.class);
         final DefaultArtifact artifact = new DefaultArtifact("g", "a", "1.0", "compile", "jar", null, new DefaultArtifactHandler());
         when(project.getArtifacts()).thenReturn(singleton(artifact));
@@ -215,7 +207,6 @@ public class ArtifactResolverTest {
 
     @Test
     public void testResolveSignaturesUnresolvedNone() throws MojoExecutionException {
-        final Log log = mock(Log.class);
         final RepositorySystem repositorySystem = mock(RepositorySystem.class);
         final MavenSession session = mock(MavenSession.class);
         final ProjectBuildingRequest projectBuildingRequest = mock(ProjectBuildingRequest.class);
@@ -233,7 +224,7 @@ public class ArtifactResolverTest {
         });
         when(repositorySystem.createArtifactWithClassifier(eq("g"), eq("a"), eq("1.0"), eq("jar"), isNull()))
                 .thenReturn(new DefaultArtifact("g", "a", "1.0", "compile", "mock-signature-artifact", null, new DefaultArtifactHandler()));
-        final ArtifactResolver resolver = new ArtifactResolver(log, repositorySystem, localRepository, remoteRepositories);
+        final ArtifactResolver resolver = new ArtifactResolver(repositorySystem, localRepository, remoteRepositories);
         final MavenProject project = mock(MavenProject.class);
         final DefaultArtifact artifact = new DefaultArtifact("g", "a", "1.0", "compile", "jar", null, new DefaultArtifactHandler());
         when(project.getArtifacts()).thenReturn(singleton(artifact));
@@ -242,13 +233,11 @@ public class ArtifactResolverTest {
                 singleton(artifact), SignatureRequirement.NONE);
         verify(repositorySystem, times(1)).createArtifactWithClassifier(
                 eq("g"), eq("a"), eq("1.0"), eq("jar"), isNull());
-        verify(log).warn(eq("No signature for g:a:jar:1.0"));
         assertEquals(resolvedSignatures.size(), 0);
     }
 
     @Test
     public void testResolveSignaturesUnresolvedStrict() throws MojoExecutionException {
-        final Log log = mock(Log.class);
         final RepositorySystem repositorySystem = mock(RepositorySystem.class);
         final MavenSession session = mock(MavenSession.class);
         final ProjectBuildingRequest projectBuildingRequest = mock(ProjectBuildingRequest.class);
@@ -266,7 +255,7 @@ public class ArtifactResolverTest {
         });
         when(repositorySystem.createArtifactWithClassifier(eq("g"), eq("a"), eq("1.0"), eq("jar"), isNull()))
                 .thenReturn(new DefaultArtifact("g", "a", "1.0", "compile", "mock-signature-artifact", null, new DefaultArtifactHandler()));
-        final ArtifactResolver resolver = new ArtifactResolver(log, repositorySystem, localRepository, remoteRepositories);
+        final ArtifactResolver resolver = new ArtifactResolver(repositorySystem, localRepository, remoteRepositories);
         final MavenProject project = mock(MavenProject.class);
         final DefaultArtifact artifact = new DefaultArtifact("g", "a", "1.0", "compile", "jar", null, new DefaultArtifactHandler());
         when(project.getArtifacts()).thenReturn(singleton(artifact));
@@ -283,7 +272,6 @@ public class ArtifactResolverTest {
 
     @Test
     public void testResolveSignaturesUnresolvedRequired() {
-        final Log log = mock(Log.class);
         final RepositorySystem repositorySystem = mock(RepositorySystem.class);
         final MavenSession session = mock(MavenSession.class);
         final ProjectBuildingRequest projectBuildingRequest = mock(ProjectBuildingRequest.class);
@@ -301,7 +289,7 @@ public class ArtifactResolverTest {
         });
         when(repositorySystem.createArtifactWithClassifier(eq("g"), eq("a"), eq("1.0"), eq("jar"), isNull()))
                 .thenReturn(new DefaultArtifact("g", "a", "1.0", "compile", "mock-signature-artifact", null, new DefaultArtifactHandler()));
-        final ArtifactResolver resolver = new ArtifactResolver(log, repositorySystem, localRepository, remoteRepositories);
+        final ArtifactResolver resolver = new ArtifactResolver(repositorySystem, localRepository, remoteRepositories);
         final MavenProject project = mock(MavenProject.class);
         final DefaultArtifact artifact = new DefaultArtifact("g", "a", "1.0", "compile", "jar", null, new DefaultArtifactHandler());
         when(project.getArtifacts()).thenReturn(singleton(artifact));

--- a/src/test/java/org/simplify4u/plugins/keysmap/KeysMapTest.java
+++ b/src/test/java/org/simplify4u/plugins/keysmap/KeysMapTest.java
@@ -16,12 +16,10 @@
 package org.simplify4u.plugins.keysmap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.simplify4u.plugins.TestArtifactBuilder.testArtifact;
 import static org.simplify4u.plugins.TestUtils.getPGPgpPublicKey;
 
 import io.vavr.control.Try;
-import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
@@ -34,16 +32,13 @@ import org.testng.annotations.Test;
  */
 public class KeysMapTest {
 
-    private PlexusContainer container = Try.of(DefaultPlexusContainer::new).get();
-
-    private Log log;
+    private final PlexusContainer container = Try.of(DefaultPlexusContainer::new).get();
 
     private KeysMap keysMap;
 
     @BeforeMethod
     public void setUp() throws ComponentLookupException {
         keysMap = container.lookup(KeysMap.class);
-        log = mock(Log.class);
     }
 
     @AfterMethod
@@ -56,33 +51,23 @@ public class KeysMapTest {
         assertThat(keysMap).isNotNull();
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void bothNullTest() throws Exception {
-        keysMap.load(null, null);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void nullLogTest() throws Exception {
-        keysMap.load(null, "keys.map");
-    }
-
     @Test
     public void nullLocationTest() throws Exception {
-        keysMap.load(log, null);
+        keysMap.load(null);
 
         assertThat(keysMap.isValidKey(testArtifact().build(), null, null)).isTrue();
     }
 
     @Test
     public void emptyLocationTest() throws Exception {
-        keysMap.load(log, "");
+        keysMap.load("");
 
         assertThat(keysMap.isValidKey(testArtifact().build(), null, null)).isTrue();
     }
 
     @Test
     public void validKeyFromMap() throws Exception {
-        keysMap.load(log, "/keysMap.list");
+        keysMap.load("/keysMap.list");
 
         assertThat(
                 keysMap.isValidKey(
@@ -138,7 +123,7 @@ public class KeysMapTest {
 
     @Test
     public void invalidKeyFromMap() throws Exception {
-        keysMap.load(log, "/keysMap.list");
+        keysMap.load("/keysMap.list");
 
         assertThat(
                 keysMap.isValidKey(
@@ -150,7 +135,7 @@ public class KeysMapTest {
     @Test
     public void specialValueNoSig() throws Exception {
 
-        keysMap.load(log, "/keysMap.list");
+        keysMap.load("/keysMap.list");
 
         assertThat(
                 keysMap.isNoSignature(testArtifact().groupId("noSig").artifactId("test").build())
@@ -175,7 +160,7 @@ public class KeysMapTest {
     @Test
     public void specialValueBadSig() throws Exception {
 
-        keysMap.load(log, "/keysMap.list");
+        keysMap.load("/keysMap.list");
 
         assertThat(
                 keysMap.isBrokenSignature(testArtifact().groupId("badSig").build())
@@ -185,7 +170,7 @@ public class KeysMapTest {
     @Test
     public void specialValueNoKey() throws Exception {
 
-        keysMap.load(log, "/keysMap.list");
+        keysMap.load("/keysMap.list");
 
         assertThat(
                 keysMap.isKeyMissing(testArtifact().groupId("noKey").build())
@@ -195,7 +180,7 @@ public class KeysMapTest {
     @Test(expectedExceptions = IllegalArgumentException.class,
             expectedExceptionsMessageRegExp = "Key length for = 0x10 is 8 bits, should be between 64 and 160 bits")
     public void shortKeyShouldThrownException() throws Exception {
-        keysMap.load(log, "/keyMap-keyToShort.list");
+        keysMap.load("/keyMap-keyToShort.list");
 
     }
 }


### PR DESCRIPTION
Misc small improvements.

- Fix javadoc linter warning.
- Consistent coding style.
- Use SLF4J logger and remove constructor injection of Log instance.
- Unnecessary nesting.

Let me know if you want it split up, or you're not interested or whatever. This is just what I gathered while investigating the issue regarding stricter treatment of missing keysmap location.

Also, let me know if you want this squashed too. I did not do it for now, as it makes clearer what sort of changes were made.