### PR TITLE
Implicitly enable verifyPlugins if verifyPluginDependencies is enabled. (Fixes #128)

### DIFF
--- a/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
+++ b/src/main/java/org/simplify4u/plugins/ArtifactResolver.java
@@ -415,6 +415,7 @@ final class ArtifactResolver {
      * Configuration struct for Artifact Resolver.
      */
     public static final class Configuration {
+
         final SkipFilter dependencyFilter;
         final SkipFilter pluginFilter;
         final boolean verifyPomFiles;
@@ -437,7 +438,7 @@ final class ArtifactResolver {
             this.dependencyFilter = requireNonNull(dependencyFilter);
             this.pluginFilter = requireNonNull(pluginFilter);
             this.verifyPomFiles = verifyPomFiles;
-            this.verifyPlugins = verifyPlugins;
+            this.verifyPlugins = verifyPlugins || verifyPluginDependencies;
             this.verifyPluginDependencies = verifyPluginDependencies;
             this.verifyAtypical = verifyAtypical;
         }

--- a/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
+++ b/src/main/java/org/simplify4u/plugins/PGPVerifyMojo.java
@@ -217,6 +217,8 @@ public class PGPVerifyMojo extends AbstractMojo {
     /**
      * Verify transitive dependencies of build plug-ins.
      *
+     * <p>When enabled, configuration parameter <code>verifyPlugins</code> is enabled implicitly.</p>
+     *
      * @since 1.8.0
      */
     @Parameter(property = "pgpverify.verifyPluginDependencies", defaultValue = "false")

--- a/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
+++ b/src/test/java/org/simplify4u/plugins/ArtifactResolverTest.java
@@ -24,7 +24,6 @@ import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.repository.RepositorySystem;
@@ -32,6 +31,7 @@ import org.mockito.stubbing.Answer;
 import org.simplify4u.plugins.ArtifactResolver.Configuration;
 import org.simplify4u.plugins.ArtifactResolver.SignatureRequirement;
 import org.simplify4u.plugins.skipfilters.CompositeSkipper;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -42,6 +42,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -295,5 +296,24 @@ public class ArtifactResolverTest {
         when(project.getArtifacts()).thenReturn(singleton(artifact));
 
         assertThrows(MojoExecutionException.class, () -> resolver.resolveSignatures(singleton(artifact), SignatureRequirement.REQUIRED));
+    }
+
+    @Test(dataProvider = "verify-plugin-dependencies-combos")
+    public void testEnablingValidatingPluginDependenciesEnablesPlugins(boolean verifyPlugins,
+                boolean verifyPluginDependencies, boolean pluginsEnabled, boolean pluginDependenciesEnabled) {
+        final Configuration config = new Configuration(new CompositeSkipper(), new CompositeSkipper(),
+                false, verifyPlugins, verifyPluginDependencies, false);
+        assertThat(config.verifyPluginDependencies).isEqualTo(pluginDependenciesEnabled);
+        assertThat(config.verifyPlugins).isEqualTo(pluginsEnabled);
+    }
+
+    @DataProvider(name = "verify-plugin-dependencies-combos")
+    public Object[][] providerVerifyPluginDependenciesCombos() {
+        return new Object[][]{
+                {false, false, false, false},
+                {false, true, true, true},
+                {true, false, true, false},
+                {true, true, true, true},
+        };
     }
 }


### PR DESCRIPTION
Enable `verifyPlugins` if `verifyPluginDependencies` is enabled.

A unit test tests the four combinations of values for `(verifyPlugins, verifyPluginDependencies)`. I'd like to avoid creating another IT test which is quite heavy on execution time.

TODO: awaiting results from sonar et al.