### PR TITLE
Fix zero padded key validation. #200

### DIFF
--- a/src/main/java/org/simplify4u/plugins/keysmap/KeyInfoItemKey.java
+++ b/src/main/java/org/simplify4u/plugins/keysmap/KeyInfoItemKey.java
@@ -15,12 +15,11 @@
  */
 package org.simplify4u.plugins.keysmap;
 
-import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Optional;
 
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
+import org.bouncycastle.util.encoders.Hex;
 import org.simplify4u.plugins.utils.PublicKeyUtils;
 
 public class KeyInfoItemKey implements KeyInfoItem {
@@ -28,7 +27,7 @@ public class KeyInfoItemKey implements KeyInfoItem {
     private final byte[] fingerPrint;
 
     public KeyInfoItemKey(String key) {
-        fingerPrint = strKeyToBytes(key.substring(2));
+        fingerPrint = strKeyToBytes(key.substring(2).replace(" ", ""));
     }
 
     @Override
@@ -43,15 +42,7 @@ public class KeyInfoItemKey implements KeyInfoItem {
     }
 
     private static byte[] strKeyToBytes(String key) {
-
-        BigInteger bigInteger = new BigInteger(key.replace(" ", ""), 16);
-
-        byte[] bytes = bigInteger.toByteArray();
-
-        if (bytes[0] == 0) {
-            // we can remove sign byte
-            bytes = Arrays.copyOfRange(bytes, 1, bytes.length);
-        }
+        byte[] bytes = Hex.decode(key);
 
         if (bytes.length < 8 || bytes.length > 20) {
             throw new IllegalArgumentException(

--- a/src/test/java/org/simplify4u/plugins/keysmap/KeyInfoTest.java
+++ b/src/test/java/org/simplify4u/plugins/keysmap/KeyInfoTest.java
@@ -49,7 +49,8 @@ public class KeyInfoTest {
                 {"0x123456789abcdef0, 0x0fedcba987654321", 0x123456789abcdef0L, true},
                 {"0x123456789abcdef0", 0x231456789abcdef0L, false},
                 {"0x123456789abcdef0, *", 0x231456789abcdef0L, true},
-                {"0x123456789abcdef0, 0x0fedcba987654321", 0x321456789abcdef0L, false}
+                {"0x123456789abcdef0, 0x0fedcba987654321", 0x321456789abcdef0L, false},
+                {"0x0000000000000001", 0x1L, true}
         };
     }
 


### PR DESCRIPTION
I gave it a go at fixing #200 . I have replaced `BigInteger` hex string parsing with BC utility class.