### PR TITLE
Include invalid key in error message.

### DIFF
--- a/src/main/java/org/simplify4u/plugins/keysmap/KeyInfoItemKey.java
+++ b/src/main/java/org/simplify4u/plugins/keysmap/KeyInfoItemKey.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
+import org.bouncycastle.util.encoders.DecoderException;
 import org.bouncycastle.util.encoders.Hex;
 import org.simplify4u.plugins.utils.PublicKeyUtils;
 
@@ -27,7 +28,7 @@ public class KeyInfoItemKey implements KeyInfoItem {
     private final byte[] fingerPrint;
 
     public KeyInfoItemKey(String key) {
-        fingerPrint = strKeyToBytes(key.substring(2).replace(" ", ""));
+        fingerPrint = strKeyToBytes(key);
     }
 
     @Override
@@ -42,11 +43,17 @@ public class KeyInfoItemKey implements KeyInfoItem {
     }
 
     private static byte[] strKeyToBytes(String key) {
-        byte[] bytes = Hex.decode(key);
+        byte[] bytes;
+
+        try {
+            bytes = Hex.decode(key.substring(2));
+        } catch (DecoderException e) {
+            throw new IllegalArgumentException("Malformed keyID hex string " + key, e);
+        }
 
         if (bytes.length < 8 || bytes.length > 20) {
             throw new IllegalArgumentException(
-                    String.format("Key length for = 0x%s is %d bits, should be between 64 and 160 bits",
+                    String.format("Key length for = %s is %d bits, should be between 64 and 160 bits",
                             key, bytes.length * 8));
         }
 

--- a/src/test/java/org/simplify4u/plugins/keysmap/KeyInfoTest.java
+++ b/src/test/java/org/simplify4u/plugins/keysmap/KeyInfoTest.java
@@ -48,6 +48,7 @@ public class KeyInfoTest {
                 {"0x123456789abcdef0,0x0fedcba987654321", 0x123456789abcdef0L, true},
                 {"0x123456789abcdef0, 0x0fedcba987654321", 0x123456789abcdef0L, true},
                 {"0x123456789abcdef0", 0x231456789abcdef0L, false},
+                {"0x12 34 56 78 9a bc de f0", 0x123456789abcdef0L, true},
                 {"0x123456789abcdef0, *", 0x231456789abcdef0L, true},
                 {"0x123456789abcdef0, 0x0fedcba987654321", 0x321456789abcdef0L, false},
                 {"0x0000000000000001", 0x1L, true}
@@ -105,4 +106,17 @@ public class KeyInfoTest {
                     });
         }
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Malformed keyID hex string 0x123456789abcdef")
+    public void oddHexStringShouldThrowException() {
+        new KeyInfo("0x123456789abcdef");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Malformed keyID hex string 0xINVALID")
+    public void invalidHexStringShouldThrowException() {
+        new KeyInfo("0xINVALID");
+    }
+
 }


### PR DESCRIPTION
Make sure error message contains invalid key in case of hex decoding error.