### PR TITLE
Ignore dependency updates which can not be used

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
   ignore:
   - dependency-name: org.apache.maven:*
   - dependency-name: org.apache.maven.resolver:*
+  # next major requires Java 17, project baseline is Java 8
+  - dependency-name: org.junit.jupiter:*
+    versions:
+    - ">=6.0.0"
+  - dependency-name: io.github.resilience4j:*
+    versions:
+    - ">=2.0.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
   - dependency-name: io.github.resilience4j:*
     versions:
     - ">=2.0.0"
+  # Maven 3.x provides slf4j 1.7.x to plugins
+  - dependency-name: org.slf4j:*
+    versions:
+    - ">=2.0.0"


### PR DESCRIPTION
Dependabot keeps opening PRs for dependencies this plugin can not take, so they are ignored at the source.

### Java 17 baseline

Project baseline is Java 8 (`maven.compiler.release`) and CI builds on JDK 8, 11, 17 and 21. Both `org.junit.jupiter` 6.x and `io.github.resilience4j` 2.x ship class files with major version 61 (Java 17).

- #712 — `junit-jupiter-api` 6.1.3, fails on jdk-8 and jdk-11
- #711 — `junit-jupiter-params` 6.1.3, same, plus a `junit-platform-commons` version split against `junit-jupiter-api` 5.13.4
- #691 — `resilience4j` 2.0.0, additionally drops vavr from its API (`PGPKeysServerClient.java:215`)

### slf4j

Maven 3.x provides slf4j 1.7.x to plugins, so the plugin stays on the same line.

- #689 — `slf4j-api` 2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)