### PR TITLE
Fix dependency convergence for org.jspecify:jspecify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,12 @@
                 <artifactId>javax.inject</artifactId>
                 <version>1</version>
             </dependency>
+            <!-- align version brought in by guava and vavr -->
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>1.0.1</version>
+            </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>


### PR DESCRIPTION
The `master` build is currently red.

`guava` 33.7.1-jre brings `org.jspecify:jspecify:1.0.1`, `io.vavr:vavr` 1.0.1 brings `1.0.0`, and the enforcer `DependencyConvergence` rule rejects the mix:

```
Dependency convergence error for org.jspecify:jspecify:jar:1.0.1. Paths to dependency are:
+-org.simplify4u.plugins:pgpverify-maven-plugin:maven-plugin:1.19.2-SNAPSHOT
  +-com.google.guava:guava:jar:33.7.1-jre:compile
    +-org.jspecify:jspecify:jar:1.0.1:compile
and
+-org.simplify4u.plugins:pgpverify-maven-plugin:maven-plugin:1.19.2-SNAPSHOT
  +-io.vavr:vavr:jar:1.0.1:compile
    +-org.jspecify:jspecify:jar:1.0.0:compile
```

Both #717 and #683 were green on their own branch, the clash only appeared once both had landed. Pinned to 1.0.1 in `dependencyManagement`.

Verified locally with a full `mvn verify` including the integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)