### PR TITLE
Use separate properties for jackson-annotations and jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,9 @@
 
     <properties>
         <bouncycastle.version>1.85</bouncycastle.version>
-        <jackson.version>2.19.2</jackson.version>
+        <!-- jackson-annotations has its own release line, without patch releases -->
+        <jackson-annotations.version>2.19.2</jackson-annotations.version>
+        <jackson-databind.version>2.19.2</jackson-databind.version>
         <mavenVersion>3.6.3</mavenVersion>
         <resolverVersion>1.4.1</resolverVersion>
         <mockito.version>4.11.0</mockito.version>
@@ -202,12 +204,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
`jackson-annotations` has its own release line and stopped publishing patch releases: `2.19.2`, `2.19.3`, `2.19.4`, then `2.20`, `2.21`, `2.22`. `jackson-databind` keeps publishing patches: `2.21.5`, `2.22.2`, and so on.

A single `jackson.version` property drove both, so every dependabot bump of a patch release asked for an artifact that was never published:

```
Could not find artifact com.fasterxml.jackson.core:jackson-annotations:jar:2.21.5 in central
```

That is what broke #709 and #700.

Split into `jackson-annotations.version` and `jackson-databind.version` so both can move independently. Checked that a split pair resolves:

```
annotations 2.22 + databind 2.22.2  ->  BUILD SUCCESS
```

Versions are left at `2.19.2` here, the actual bumps are left to dependabot. Verified locally with a full `mvn verify` including the integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)